### PR TITLE
Faster field alignment + full Equatorial mount support

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from pointing_model import PointingModel, fibonacci_sky_grid
+from eq_pointing_model import EquatorialPointingModel
 
 # Phases of the alignment run (surfaced to the UI).
 IDLE = "idle"
@@ -93,26 +94,24 @@ class AlignmentState:
         self.view_mode = view
 
 
-def slew_to_azel(controller, config_state, az_deg, el_deg, timeout=20.0,
-                 tol_deg=0.02, settle_cycles=3, kp=4.0, max_dps=5.0, position_cb=None):
-    """Slew the mount so the boresight points at sky (az, el) and wait for it to settle.
+def _assumed_pole(config_state):
+    """Assumed (aligned) celestial-pole direction for Eq mode: (pole_az, pole_alt)."""
+    pole_az = float(getattr(config_state, 'alignment_azimuth_str', 0.0) or 0.0)
+    pole_alt = float(getattr(config_state, 'alignment_elevation_str', 0.0) or 0.0)
+    if pole_alt == 0.0:
+        pole_alt = float(getattr(config_state, 'lat_str', 0.0) or 0.0)
+    return pole_az, pole_alt
 
-    Coarse goto for the bulk move, then a proportional continuous-rate (guide-rate)
-    settle onto the target. Using hc_set_rate_dps (not the coarse discrete MC_MOVE
-    table, whose mid rates are far too slow for fine settling) converges smoothly
-    without overshoot. The closed-loop settle is what makes the encoder bias show up as
-    a real pointing error in the sim, and matches real hardware where goto alone isn't
-    accurate. Uses the BASE transform (no pointing model) to measure raw mount
-    behaviour. Returns True if it settled within tolerance.
+
+def _settle_to_mount(controller, azm_t, alt_t, timeout, tol_deg, settle_cycles,
+                     kp, max_dps, position_cb, to_sky):
+    """Coarse goto + proportional continuous-rate settle onto mount axes (azm_t, alt_t).
+
+    ``to_sky(azm, alt) -> (az, el)`` converts the live encoder reading for the position
+    callback. Shared by the AltAz and Eq slews so only the sky<->mount transform differs.
+    Returns True if it settled within tolerance.
     """
-    from transformations import AzEl2AzAlt_AltAz, AzAlt2AzEl_AltAz
     from lib.auxstar import Targets
-
-    align_az = float(getattr(config_state, 'alignment_azimuth_str', 0.0) or 0.0)
-    align_el = float(getattr(config_state, 'alignment_elevation_str', 0.0) or 0.0)
-    azm_t, alt_t = AzEl2AzAlt_AltAz(az_deg, el_deg, align_az, align_el)
-
-    # Coarse jump to get within the settle window quickly.
     try:
         controller.hc_goto_fast(Targets.AZM, azm_t, 0, 0)
         controller.hc_goto_fast(Targets.ALT, alt_t, 0, 0)
@@ -121,14 +120,10 @@ def slew_to_azel(controller, config_state, az_deg, el_deg, timeout=20.0,
 
     use_rate = hasattr(controller, 'hc_set_rate_dps')
 
-    def _clamp(v):
-        return max(-max_dps, min(max_dps, v))
-
     def _command(target, err):
         if use_rate:
-            controller.hc_set_rate_dps(target, _clamp(kp * err))
+            controller.hc_set_rate_dps(target, max(-max_dps, min(max_dps, kp * err)))
         else:
-            # Fallback: fastest discrete rate scaled to the error (coarse).
             r = 9 if abs(err) > 2 else 7 if abs(err) > 0.5 else 5 if abs(err) > 0.1 else 3
             controller.hc_slew_fixed(target, r * (1 if err > 0 else -1))
 
@@ -148,11 +143,11 @@ def slew_to_azel(controller, config_state, az_deg, el_deg, timeout=20.0,
         cur_alt = controller.hc_get_position(Targets.ALT) * 360.0
         if position_cb is not None:
             try:
-                position_cb(*AzAlt2AzEl_AltAz(cur_azm, cur_alt, align_az))
+                position_cb(*to_sky(cur_azm, cur_alt))
             except Exception:
                 pass
         e_az = _wrap180(azm_t - cur_azm)
-        e_alt = alt_t - cur_alt
+        e_alt = _wrap180(alt_t - cur_alt)
         if abs(e_az) < tol_deg and abs(e_alt) < tol_deg:
             stable += 1
             if stable >= settle_cycles:
@@ -166,6 +161,35 @@ def slew_to_azel(controller, config_state, az_deg, el_deg, timeout=20.0,
 
     _stop()
     return abs(e_az) < tol_deg * 5 and abs(e_alt) < tol_deg * 5
+
+
+def slew_to_azel(controller, config_state, az_deg, el_deg, timeout=20.0,
+                 tol_deg=0.02, settle_cycles=3, kp=4.0, max_dps=5.0, position_cb=None):
+    """Slew the mount so the boresight points at sky (az, el) (AltAz mode) and settle.
+
+    Coarse goto then a proportional continuous-rate (guide-rate) settle. Uses the BASE
+    AltAz transform (no pointing model) to measure raw mount behaviour. Returns True if it
+    settled within tolerance.
+    """
+    from transformations import AzEl2AzAlt_AltAz, AzAlt2AzEl_AltAz
+    align_az = float(getattr(config_state, 'alignment_azimuth_str', 0.0) or 0.0)
+    align_el = float(getattr(config_state, 'alignment_elevation_str', 0.0) or 0.0)
+    azm_t, alt_t = AzEl2AzAlt_AltAz(az_deg, el_deg, align_az, align_el)
+    return _settle_to_mount(controller, azm_t, alt_t, timeout, tol_deg, settle_cycles,
+                            kp, max_dps, position_cb,
+                            lambda azm, alt: AzAlt2AzEl_AltAz(azm, alt, align_az))
+
+
+def slew_to_azel_eq(controller, config_state, az_deg, el_deg, timeout=20.0,
+                    tol_deg=0.1, settle_cycles=2, kp=4.0, max_dps=5.0, position_cb=None):
+    """Eq-mode slew: convert sky (az, el) to mount (hour-angle, dec) about the assumed pole
+    and settle the AZM (HA) / ALT (Dec) axes. Returns True if it settled within tolerance."""
+    from transformations import azel_to_eq_mount, eq_mount_to_azel
+    pole_az, pole_alt = _assumed_pole(config_state)
+    azm_t, alt_t = azel_to_eq_mount(az_deg, el_deg, pole_az, pole_alt)
+    return _settle_to_mount(controller, azm_t, alt_t, timeout, tol_deg, settle_cycles,
+                            kp, max_dps, position_cb,
+                            lambda azm, alt: eq_mount_to_azel(azm, alt, pole_az, pole_alt))
 
 
 class GuiSampler:
@@ -201,11 +225,21 @@ class GuiSampler:
             self.align_state.current_mount_azel = (az, el)
 
     def slew(self, az, el):
-        """Coarse goto + closed-loop settle onto (az, el). Returns True if it settled."""
+        """Coarse goto + closed-loop settle onto (az, el). Returns True if it settled.
+
+        Uses a loose, config-driven settle tolerance: capture() pairs the encoder reading
+        at solve time with the solved sky position, so landing a fraction of a degree off
+        the grid point costs no accuracy -- only "stopped moving, in a star-rich field"
+        matters. Tight settling here is the main dusk-time waste, so it is avoided.
+        """
         controller = getattr(self.joystick_state, 'telescope_controller', None)
         if controller is None:
             return False
-        ok = slew_to_azel(controller, self.config_state, az, el, position_cb=self._publish_pos)
+        cfg = self.config_state
+        tol = float(getattr(cfg, 'alignment_settle_tol_deg', 0.3) or 0.3)
+        cycles = int(getattr(cfg, 'alignment_settle_cycles', 2) or 2)
+        ok = slew_to_azel(controller, cfg, az, el, tol_deg=tol, settle_cycles=cycles,
+                          position_cb=self._publish_pos)
         time.sleep(self.settle_pause)  # let the camera grab a fresh post-slew frame
         return ok
 
@@ -264,11 +298,69 @@ class GuiSampler:
             pass
 
 
+class EqGuiSampler(GuiSampler):
+    """Eq-mode sampler: slews in HA/Dec about the assumed pole and returns samples in mount
+    HA/Dec space ``(h_cmd, d_cmd, h_obs, d_obs, meta)`` for the equatorial pointing-model fit.
+
+    h_cmd/d_cmd are the encoder axes at solve time (AZM=HA, ALT=Dec) directly; h_obs/d_obs are
+    the plate-solved sky position mapped back to HA/Dec through the assumed pole geometry.
+    """
+
+    def slew(self, az, el):
+        controller = getattr(self.joystick_state, 'telescope_controller', None)
+        if controller is None:
+            return False
+        cfg = self.config_state
+        tol = float(getattr(cfg, 'alignment_settle_tol_deg', 0.3) or 0.3)
+        cycles = int(getattr(cfg, 'alignment_settle_cycles', 2) or 2)
+        ok = slew_to_azel_eq(controller, cfg, az, el, tol_deg=tol, settle_cycles=cycles,
+                             position_cb=self._publish_pos)
+        time.sleep(self.settle_pause)
+        return ok
+
+    def capture(self):
+        import camera_manager
+        from transformations import azel_to_eq_mount
+        import plate_solver as ps_mod
+        from lib.auxstar import Targets
+
+        controller = getattr(self.joystick_state, 'telescope_controller', None)
+        if controller is None:
+            return None
+        camera = camera_manager.camera_manager.get_camera(self.cam_index)
+        raw = (camera.thread.get_latest_raw()
+               if camera is not None and getattr(camera, 'thread', None) is not None else None)
+        if raw is None:
+            return None
+        t = self.ts.now()
+        result = self.solver.solve(raw)
+        if result is None or not result.solved:
+            return None
+        cfg = self.config_state
+        lat = float(cfg.lat_str or 0.0); lon = float(cfg.lon_str or 0.0)
+        elev = float(cfg.alt_str or 0.0)
+        az_obs, el_obs = ps_mod.solved_azel(result.ra_deg, result.dec_deg, lat, lon, elev,
+                                            self.ephemeris, self.ts, t)
+        pole_az, pole_alt = _assumed_pole(cfg)
+        h_obs, d_obs = azel_to_eq_mount(az_obs, el_obs, pole_az, pole_alt)
+        h_cmd = controller.hc_get_position(Targets.AZM) * 360.0
+        d_cmd = controller.hc_get_position(Targets.ALT) * 360.0
+        h_cmd = _wrap180(h_cmd)
+        meta = {'result': result, 'az_obs': az_obs % 360.0, 'el_obs': el_obs,
+                'n_matches': result.n_matches, 'fov': result.fov_deg, 'rmse': result.rmse,
+                'cam_index': self.cam_index, 't': t}
+        if self.align_state is not None:
+            self.align_state.last_solve = meta
+            self.align_state.current_mount_azel = (az_obs % 360.0, el_obs)
+        return (h_cmd, d_cmd, _wrap180(h_obs), d_obs, meta)
+
+
 def make_default_sample_fn(joystick_state, config_state, solver, ts, ephemeris,
                            cam_index=0, settle_pause=0.4, align_state=None):
-    """Build the GUI sampler (slew + capture + plate-solve). See GuiSampler."""
-    return GuiSampler(joystick_state, config_state, solver, ts, ephemeris,
-                      cam_index, settle_pause, align_state)
+    """Build the GUI sampler (slew + capture + plate-solve), alt-az or Eq by mount mode."""
+    cls = EqGuiSampler if getattr(config_state, 'mount_mode', 'AltAz') == 'Eq' else GuiSampler
+    return cls(joystick_state, config_state, solver, ts, ephemeris,
+               cam_index, settle_pause, align_state)
 
 
 class AlignmentRunner(threading.Thread):
@@ -284,7 +376,9 @@ class AlignmentRunner(threading.Thread):
     def __init__(self, align_state, config_state, sampler,
                  n_points=18, holdout_frac=0.25, el_min=None, el_max=80.0,
                  remove_refraction=False, status_cb=None,
-                 pending_points=None, append=False, grid_cells=None):
+                 pending_points=None, append=False, grid_cells=None,
+                 seed_terms=None, free_terms=None, target_rms_arcmin=None, robust=True,
+                 eq_mode=None):
         super().__init__(daemon=True)
         self.s = align_state
         self.config_state = config_state
@@ -300,6 +394,21 @@ class AlignmentRunner(threading.Thread):
         self.status_cb = status_cb
         self.pending_points = pending_points
         self.append = append
+        # Partial (nightly-refresh) fit: hold all but ``free_terms`` at ``seed_terms``.
+        self.seed_terms = seed_terms
+        self.free_terms = free_terms
+        # Adaptive early-stop target (arcmin); falls back to config, 0 disables.
+        if target_rms_arcmin is None:
+            target_rms_arcmin = float(getattr(config_state, 'alignment_target_rms_arcmin', 0.0) or 0.0)
+        self.target_rms_arcmin = float(target_rms_arcmin)
+        # Reject gross-outlier solves (bad matches, a satellite in the field) before the final fit.
+        self.robust = bool(robust)
+        # Equatorial mode fits the EQ pointing model in hour-angle/dec space; the sampler then
+        # returns (h_cmd, d_cmd, h_obs, d_obs) instead of (az_cmd, el_cmd, az_obs, el_obs).
+        if eq_mode is None:
+            eq_mode = getattr(config_state, 'mount_mode', 'AltAz') == 'Eq'
+        self.eq_mode = bool(eq_mode)
+        self.lat_deg = float(getattr(config_state, 'lat_str', 0.0) or 0.0)
         if grid_cells is None:
             grid_cells = int(getattr(config_state, 'alignment_grid_search_cells', 100) or 0)
         self.grid_cells = max(0, int(grid_cells))
@@ -407,6 +516,18 @@ class AlignmentRunner(threading.Thread):
             s.samples.append(smp[:4])
             s.sample_meta.append(meta)
 
+    def _fit(self, samples):
+        """Fit the pointing model from samples, honouring partial-fit (seed/free) options.
+
+        Eq mode fits the equatorial model in HA/Dec space; AltAz fits the alt-az model.
+        """
+        if self.eq_mode:
+            return EquatorialPointingModel.fit(samples, self.lat_deg, seed_terms=self.seed_terms,
+                                               free_terms=self.free_terms, robust=self.robust)
+        return PointingModel.fit(samples, remove_refraction=self.remove_refraction,
+                                 seed_terms=self.seed_terms, free_terms=self.free_terms,
+                                 robust=self.robust)
+
     # ---- main loop ------------------------------------------------------------
     def run(self):
         s = self.s
@@ -431,6 +552,12 @@ class AlignmentRunner(threading.Thread):
             # --- collect fit samples ---
             s.phase = RUNNING
             total = len(pending)
+            # Adaptive early-stop: once the running fit is good enough (and enough points are
+            # covered) for two consecutive checks, stop sampling the rest of the grid. The
+            # Fibonacci grid is ordered by the golden angle, so the first dozen points already
+            # span azimuth well -- the tail mostly refines an already-good fit.
+            early_floor = max(MIN_SAMPLES + 6, 12)
+            consec_good = 0
             for i, (az, el) in enumerate(pending):
                 if self._abort.is_set():
                     s.phase = IDLE
@@ -443,6 +570,21 @@ class AlignmentRunner(threading.Thread):
                     self._record(smp, 'fit')
                 else:
                     s.failed_points.append((az, el))
+
+                if (self.target_rms_arcmin > 0 and not self.append
+                        and len(s.samples) >= early_floor and i + 1 < total):
+                    try:
+                        _m, _st = self._fit(s.samples)
+                        if _st['rms_after_arcmin'] <= self.target_rms_arcmin:
+                            consec_good += 1
+                        else:
+                            consec_good = 0
+                        if consec_good >= 2:
+                            self._status(f"early-stop: fit RMS {_st['rms_after_arcmin']:.2f}' "
+                                         f"<= {self.target_rms_arcmin:.2f}' after {len(s.samples)}/{total}")
+                            break
+                    except Exception:
+                        consec_good = 0
             s.progress = (total, total)
 
             if len(s.samples) < MIN_SAMPLES:
@@ -455,7 +597,7 @@ class AlignmentRunner(threading.Thread):
 
             # --- fit ---
             self._status("fitting pointing model...")
-            model, stats = PointingModel.fit(s.samples, remove_refraction=self.remove_refraction)
+            model, stats = self._fit(s.samples)
             s.model = model
             s.stats = stats
 
@@ -472,8 +614,11 @@ class AlignmentRunner(threading.Thread):
                     else:
                         s.failed_points.append((az, el))
             if s.backtest_samples:
-                s.backtest_rms_deg = model.backtest(s.backtest_samples,
-                                                    remove_refraction=self.remove_refraction)
+                if self.eq_mode:
+                    s.backtest_rms_deg = model.backtest(s.backtest_samples)
+                else:
+                    s.backtest_rms_deg = model.backtest(s.backtest_samples,
+                                                        remove_refraction=self.remove_refraction)
 
             s.current_target = None
             s.phase = DONE
@@ -495,11 +640,15 @@ class AlignmentRunner(threading.Thread):
 
 
 def accept_alignment(align_state, config_state, save=True):
-    """Write the fitted model into config and enable it."""
+    """Write the fitted model into config and enable it (alt-az or equatorial by type)."""
     if align_state.model is None:
         return False
-    config_state.pointing_model_terms = align_state.model.to_config()
-    config_state.pointing_model_enabled = True
+    if isinstance(align_state.model, EquatorialPointingModel):
+        config_state.eq_pointing_model_terms = align_state.model.to_config()
+        config_state.eq_pointing_model_enabled = True
+    else:
+        config_state.pointing_model_terms = align_state.model.to_config()
+        config_state.pointing_model_enabled = True
     if save:
         try:
             config_state.save_to_file()

--- a/alignment_ui.py
+++ b/alignment_ui.py
@@ -13,6 +13,7 @@ import pygame
 
 from pointing_model import TERM_NAMES
 import alignment as al
+import polar_align as pa
 
 
 def _btn(surface, rect, label, font, bg=(70, 70, 70), fg=(255, 255, 255)):
@@ -164,10 +165,6 @@ def draw_alignment_options(display, config_state, align_state, joystick_state=No
     screen.blit(display.large_font.render("Pointing-Model Alignment", True, (255, 255, 255)), (x0, y0))
 
     mount_mode = getattr(config_state, 'mount_mode', 'AltAz')
-    if mount_mode != 'AltAz':
-        screen.blit(display.font.render(
-            f"Alignment supports AltAz mount mode only (current: {mount_mode}).",
-            True, (255, 180, 120)), (x0, y0 + 44))
 
     running = align_state.phase in (al.RUNNING, al.BACKTEST)
 
@@ -195,6 +192,23 @@ def draw_alignment_options(display, config_state, align_state, joystick_state=No
          bg=(110, 50, 50) if connected else (60, 60, 60))
     display.align_connect_rect = conn_rect
     display.align_disconnect_rect = disc_rect
+
+    # This button slot is mode-dependent: in Eq mode it runs plate-solve POLAR ALIGNMENT (the
+    # fast dusk tool for field-rotation-free imaging); in AltAz mode it runs a QUICK REFIT of
+    # the index errors (IA/IE) holding the stable mechanical terms at the configured model.
+    is_eq = mount_mode == 'Eq'
+    quick_rect = pygame.Rect(x0 + 676, y0 + 44, 150, 34)
+    polar_running = bool(getattr(align_state, 'polar', None)) and align_state.polar.phase == pa.RUNNING
+    if is_eq:
+        _btn(screen, quick_rect, "Polar Align", display.small_font,
+             bg=(120, 90, 40) if (not polar_running and not running) else (90, 80, 50))
+    else:
+        pm_terms = getattr(config_state, 'pointing_model_terms', None) or {}
+        has_model = any(abs(float(pm_terms.get(k, 0.0))) > 1e-9 for k in ("AN", "AW", "NPAE", "CA", "TF"))
+        _btn(screen, quick_rect, "Quick Refit (IA/IE)", display.small_font,
+             bg=(40, 110, 110) if (has_model and not running) else (60, 60, 60))
+    display.align_quick_rect = quick_rect
+
     readout = "mount: not connected"
     if connected:
         try:
@@ -206,7 +220,7 @@ def draw_alignment_options(display, config_state, align_state, joystick_state=No
             readout = f"mount  Az {saz:6.1f}°  El {sel:5.1f}°"
         except Exception:
             readout = "mount: connected"
-    screen.blit(display.small_font.render(readout, True, (170, 200, 230)), (x0 + 676, y0 + 54))
+    screen.blit(display.small_font.render(readout, True, (170, 200, 230)), (x0, y0 + 184))
 
     # n_points stepper.
     npts = int(getattr(align_state, 'requested_points', 18))
@@ -221,8 +235,9 @@ def draw_alignment_options(display, config_state, align_state, joystick_state=No
     display.align_points_minus = minus
     display.align_points_plus = plus
 
-    # Pointing-model master toggle.
-    pm_on = bool(getattr(config_state, 'pointing_model_enabled', False))
+    # Pointing-model master toggle (mode-aware: alt-az or equatorial model).
+    pm_attr = 'eq_pointing_model_enabled' if is_eq else 'pointing_model_enabled'
+    pm_on = bool(getattr(config_state, pm_attr, False))
     pm_rect = pygame.Rect(x0 + 250, y0 + 86, 130, 26)
     _btn(screen, pm_rect, f"Model: {'ON' if pm_on else 'OFF'}", display.small_font,
          bg=(20, 110, 60) if pm_on else (90, 60, 60))
@@ -300,19 +315,29 @@ def draw_alignment_options(display, config_state, align_state, joystick_state=No
         pass  # the manual banner already owns the right-header band
     elif align_state.stats is not None:
         st = align_state.stats
+        nrej = int(st.get('n_rejected', 0) or 0)
+        rej_txt = f"  (-{nrej} outlier{'s' if nrej != 1 else ''})" if nrej else ""
         screen.blit(display.font.render(
             f"Fit RMS: {st['rms_before_arcmin']:.2f}'  ->  {st['rms_after_arcmin']:.2f}'  "
-            f"(n={st['n_samples']})", True, (200, 255, 200)), (rhx, y0 + 40))
+            f"(n={st['n_samples']}{rej_txt})", True, (200, 255, 200)), (rhx, y0 + 40))
         if align_state.backtest_rms_deg is not None:
             screen.blit(display.font.render(
                 f"Backtest RMS (held-out): {align_state.backtest_rms_deg * 60.0:.2f}'",
                 True, (180, 230, 255)), (rhx, y0 + 64))
         terms = align_state.model.terms
-        for i, k in enumerate(TERM_NAMES):
+        for i, k in enumerate(terms):  # alt-az (IA/IE/...) or equatorial (IH/ID/...) by model
             col = rhx + (i % 3) * 150
             row = (y0 + 94) + (i // 3) * 22
             screen.blit(display.small_font.render(f"{k}: {terms[k]:+.4f}°", True, (230, 230, 200)),
                         (col, row))
+        # Warn when the sampled geometry can't cleanly separate the terms (ill-conditioned).
+        cond = float(st.get('design_cond', 0.0) or 0.0)
+        if cond > 1e3:
+            screen.blit(display.small_font.render(
+                f"⚠ ill-conditioned grid (cond {cond:.0f}) - spread points wider in az/el",
+                True, (255, 200, 120)), (rhx, (y0 + 94) + 3 * 22))
+    elif is_eq:
+        _draw_polar_results(display, align_state, rhx, y0 + 40)
     else:
         _draw_prereqs(display, config_state, joystick_state, rhx, y0 + 40)
 
@@ -345,10 +370,12 @@ def handle_alignment_click(pos, display, config_state, align_state, joystick_sta
         return True
 
     if getattr(display, 'align_model_toggle_rect', None) and display.align_model_toggle_rect.collidepoint(pos):
-        config_state.pointing_model_enabled = not bool(getattr(config_state, 'pointing_model_enabled', False))
+        attr = ('eq_pointing_model_enabled' if getattr(config_state, 'mount_mode', 'AltAz') == 'Eq'
+                else 'pointing_model_enabled')
+        setattr(config_state, attr, not bool(getattr(config_state, attr, False)))
         config_state.save_to_file()
-        status_messages.append(
-            f"Pointing model {'ENABLED' if config_state.pointing_model_enabled else 'DISABLED'}")
+        kind = 'Equatorial' if attr.startswith('eq_') else 'Alt-az'
+        status_messages.append(f"{kind} pointing model {'ENABLED' if getattr(config_state, attr) else 'DISABLED'}")
         return True
 
     # View toggle (camera <-> tables) for the right panel.
@@ -394,7 +421,10 @@ def handle_alignment_click(pos, display, config_state, align_state, joystick_sta
         runner = getattr(align_state, 'runner', None)
         if runner is not None:
             runner.abort()
-            status_messages.append("Alignment abort requested")
+        pstate = getattr(align_state, 'polar', None)
+        if pstate is not None and getattr(pstate, 'runner', None) is not None:
+            pstate.runner.abort()
+        status_messages.append("Alignment abort requested")
         return True
 
     if getattr(display, 'align_accept_rect', None) and display.align_accept_rect.collidepoint(pos):
@@ -409,6 +439,14 @@ def handle_alignment_click(pos, display, config_state, align_state, joystick_sta
         _retry_failed(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages)
         return True
 
+    # Mode-dependent button: Polar Align (Eq) or Quick Refit IA/IE (AltAz).
+    if getattr(display, 'align_quick_rect', None) and display.align_quick_rect.collidepoint(pos):
+        if getattr(config_state, 'mount_mode', 'AltAz') == 'Eq':
+            _start_polar_align(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages)
+        else:
+            _start_quick_refit(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages)
+        return True
+
     if getattr(display, 'align_start_rect', None) and display.align_start_rect.collidepoint(pos):
         _start_alignment(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages)
         return True
@@ -420,8 +458,9 @@ def _start_alignment(config_state, align_state, joystick_state, tracking_vis_sta
     if align_state.phase in (al.RUNNING, al.BACKTEST):
         status_messages.append("Alignment already running")
         return
-    if getattr(config_state, 'mount_mode', 'AltAz') != 'AltAz':
-        status_messages.append("Alignment requires AltAz mount mode")
+    mode = getattr(config_state, 'mount_mode', 'AltAz')
+    if mode not in ('AltAz', 'Eq'):
+        status_messages.append("Alignment requires AltAz or Eq mount mode")
         return
 
     sampler = _prepare_alignment_run(config_state, align_state, joystick_state,
@@ -435,8 +474,105 @@ def _start_alignment(config_state, align_state, joystick_state, tracking_vis_sta
     runner = al.AlignmentRunner(align_state, config_state, sampler, n_points=npts)
     align_state.runner = runner
     runner.start()
-    status_messages.append(f"Alignment started ({npts} points, cam{sampler.cam_index + 1}, "
-                           f"DB {sampler.solver.db_name})")
+    model_kind = "equatorial" if mode == 'Eq' else "alt-az"
+    status_messages.append(f"{model_kind.capitalize()} alignment started ({npts} points, "
+                           f"cam{sampler.cam_index + 1}, DB {sampler.solver.db_name})")
+
+
+def _start_polar_align(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages):
+    """Plate-solve polar alignment (Eq mode): rotate the RA axis through a span, solve each,
+    fit the RA-axis direction, and report the az/alt knob correction to the true pole."""
+    pstate = getattr(align_state, 'polar', None)
+    if pstate is not None and pstate.phase == pa.RUNNING:
+        status_messages.append("Polar align already running")
+        return
+    if getattr(config_state, 'mount_mode', 'AltAz') != 'Eq':
+        status_messages.append("Polar align is for Eq mount mode")
+        return
+    lat = float(getattr(config_state, 'lat_str', 0.0) or 0.0)
+    if lat == 0.0:
+        status_messages.append("Set site latitude first (Config) - needed for the pole direction")
+        return
+
+    gs = _prepare_alignment_run(config_state, align_state, joystick_state,
+                                tracking_vis_state, ts, status_messages)
+    if gs is None:
+        return
+    # True celestial pole in the local horizontal frame: north (az 0) at altitude=|lat| in the
+    # northern hemisphere, south (az 180) in the southern.
+    target_az = 0.0 if lat >= 0 else 180.0
+    target_alt = abs(lat)
+    sampler = pa.make_polar_sampler(gs.joystick_state, gs.config_state, gs.solver, gs.ts,
+                                    gs.ephemeris, gs.cam_index, state=None)
+    pstate = pa.PolarAlignState()
+    align_state.polar = pstate
+    sampler.state = pstate
+    runner = pa.PolarAlignRunner(pstate, config_state, sampler, target_az, target_alt,
+                                 n_points=6, dec_deg=20.0, ha_span_deg=90.0)
+    pstate.runner = runner
+    runner.start()
+    status_messages.append(f"Polar align started (6 RA steps, cam{gs.cam_index + 1})")
+
+
+def _draw_polar_results(display, align_state, x, y):
+    """Render polar-alignment status / measured error in the right-header band (Eq mode)."""
+    screen = display.menu_screen
+    pstate = getattr(align_state, 'polar', None)
+    if pstate is None:
+        screen.blit(display.font.render("Polar Align (Eq): rotate RA axis, solve, fit the pole.",
+                                        True, (210, 220, 235)), (x, y))
+        screen.blit(display.small_font.render(
+            "Press Polar Align to measure the polar-axis error, then dial it out on the knobs.",
+            True, (160, 175, 195)), (x, y + 26))
+        return
+    screen.blit(display.font.render(f"Polar Align: {pstate.status or pstate.phase}",
+                                    True, (210, 230, 255)), (x, y))
+    done, total = pstate.progress
+    if total:
+        screen.blit(display.small_font.render(f"step {done}/{total}", True, (200, 210, 220)),
+                    (x, y + 26))
+    r = getattr(pstate, 'result', None)
+    if r is not None:
+        screen.blit(display.font.render(f"Polar error: {r['total_deg']:.2f}°",
+                                        True, (200, 255, 200)), (x, y + 48))
+        screen.blit(display.small_font.render(
+            f"Azimuth: move pole {abs(r['az_error']):.2f}° {r['az_dir']}",
+            True, (235, 225, 200)), (x, y + 74))
+        screen.blit(display.small_font.render(
+            f"Altitude: move pole {abs(r['alt_error']):.2f}° {r['alt_dir']}",
+            True, (235, 225, 200)), (x, y + 94))
+
+
+def _start_quick_refit(config_state, align_state, joystick_state, tracking_vis_state, ts, status_messages):
+    """Fast nightly refresh: re-fit only the index errors IA/IE from a handful of points,
+    holding the stable mechanical terms at the currently-configured model. Mechanical terms
+    (axis tilts, non-perpendicularity, collimation, flexure) don't change night to night --
+    only the zero-points drift with re-leveling -- so this reaches a good model in ~1 minute."""
+    if align_state.phase in (al.RUNNING, al.BACKTEST):
+        status_messages.append("Alignment already running")
+        return
+    if getattr(config_state, 'mount_mode', 'AltAz') != 'AltAz':
+        status_messages.append("Alignment requires AltAz mount mode")
+        return
+    seed = dict(getattr(config_state, 'pointing_model_terms', None) or {})
+    if not any(abs(float(seed.get(k, 0.0))) > 1e-9 for k in ("AN", "AW", "NPAE", "CA", "TF")):
+        status_messages.append("No baseline model to seed - run a full Start Alignment first")
+        return
+
+    sampler = _prepare_alignment_run(config_state, align_state, joystick_state,
+                                     tracking_vis_state, ts, status_messages)
+    if sampler is None:
+        return
+
+    npts = 8  # IA/IE need only a small, well-spread set of points
+    align_state.reset()
+    align_state.requested_points = npts
+    runner = al.AlignmentRunner(align_state, config_state, sampler, n_points=npts,
+                                holdout_frac=0.25, seed_terms=seed, free_terms=["IA", "IE"],
+                                target_rms_arcmin=0.0)
+    align_state.runner = runner
+    runner.start()
+    status_messages.append(f"Quick refit started (IA/IE, {npts} points, cam{sampler.cam_index + 1})")
 
 
 def _prepare_alignment_run(config_state, align_state, joystick_state, tracking_vis_state,

--- a/config.py
+++ b/config.py
@@ -37,11 +37,33 @@ class ConfigState:
         # giving up / pausing for a manual jog.
         self.alignment_grid_search_cells = 100
 
+        # Alignment slew settle: the plate-solve pairs the encoder reading AT SOLVE TIME
+        # with the solved sky position, so the sample is correct no matter how far from the
+        # grid point we land -- the mount only needs to be *near* a star-rich field and to
+        # have stopped moving enough that stars don't streak. A loose tolerance + few settle
+        # cycles is therefore the single biggest dusk-time saver (a tight 0.02 deg asymptotic
+        # settle wastes seconds per point for zero accuracy gain). Degrees / cycles.
+        self.alignment_settle_tol_deg = 0.3
+        self.alignment_settle_cycles = 2
+
+        # Adaptive early-stop: once the running fit's post-fit sky RMS (arcmin) drops to/below
+        # this for two consecutive checks (and enough points are covered), stop sampling the
+        # remaining fit grid early. Disabled by default (0.0 -> always sample the full grid):
+        # with few, azimuth-correlated points the per-term accuracy (esp. NPAE/CA) softens, so
+        # this is opt-in. Set e.g. 0.75 to trade a little term accuracy for a faster run.
+        self.alignment_target_rms_arcmin = 0.0
+
         # Pointing model (7-term alt-az TPOINT). Coefficients in degrees; applied as a
         # Python pre-step at target-setting time when pointing_model_enabled is True.
         self.pointing_model_enabled = False
         self.pointing_model_terms = {"IA": 0.0, "IE": 0.0, "AN": 0.0, "AW": 0.0,
                                      "NPAE": 0.0, "CA": 0.0, "TF": 0.0}
+
+        # Equatorial (Eq-mode) 7-term pointing model: residual mount errors after polar
+        # alignment (eq_pointing_model.py). Applied in hour-angle/dec space in the Eq branch.
+        self.eq_pointing_model_enabled = False
+        self.eq_pointing_model_terms = {"IH": 0.0, "ID": 0.0, "NP": 0.0, "CH": 0.0,
+                                        "ME": 0.0, "MA": 0.0, "TF": 0.0}
 
         # Position offset configuration
         self.azm_offset_str = "0.0"
@@ -93,6 +115,21 @@ class ConfigState:
             "mount_backlash_deg": 0.0,          # gear lost-motion on reversal (AVX ~0.006 = 22")
             "mount_pe_amplitude_deg": 0.0,      # periodic error, zero-to-peak (AVX ~0.003 = 11")
             "mount_pe_period_sec": 600.0,       # worm period (AVX ~10 min)
+            # Injected 7-term alt-az pointing model: the repeatable mount/optical errors the
+            # alignment routine must recover (encoder bias above is only an IA/IE-like offset).
+            # Empty/zero = no distortion. Used by the sim render so the rendered boresight lands
+            # where predict_observed() says -- letting an alignment run recover all seven terms.
+            "mount_pointing_model": {},         # e.g. {"IA":0.4,"IE":-0.2,"AN":0.05,...} (degrees)
+            "sim_refraction": False,            # add atmospheric refraction to the apparent elevation
+            "sim_refraction_pressure_mbar": 1010.0,
+            "sim_refraction_temperature_c": 10.0,
+            # Equatorial-mode polar-axis misalignment (degrees) the polar-alignment routine
+            # must measure: the sim's TRUE polar axis = (north + az_err, latitude + alt_err).
+            "sim_pole_az_err_deg": 0.0,
+            "sim_pole_alt_err_deg": 0.0,
+            # Injected equatorial residual pointing model (IH/ID/NP/CH/ME/MA/TF, degrees) the
+            # Eq-mode alignment must recover -- applied in HA/Dec before the pole geometry.
+            "mount_eq_pointing_model": {},
             "cam2_offset_rotation_deg": 0.0,    # inter-camera misalignment
             "cam2_offset_x_px": 0.0,
             "cam2_offset_y_px": 0.0,
@@ -202,8 +239,13 @@ class ConfigState:
             "plate_solve_enabled": self.plate_solve_enabled,
             "plate_solve_camera_index": self.plate_solve_camera_index,
             "alignment_grid_search_cells": self.alignment_grid_search_cells,
+            "alignment_settle_tol_deg": self.alignment_settle_tol_deg,
+            "alignment_settle_cycles": self.alignment_settle_cycles,
+            "alignment_target_rms_arcmin": self.alignment_target_rms_arcmin,
             "pointing_model_enabled": self.pointing_model_enabled,
             "pointing_model_terms": self.pointing_model_terms,
+            "eq_pointing_model_enabled": self.eq_pointing_model_enabled,
+            "eq_pointing_model_terms": self.eq_pointing_model_terms,
             "azm_offset": self.azm_offset_str,
             "alt_offset": self.alt_offset_str,
             "azm_limit_min": self.azm_limit_min_str,
@@ -252,9 +294,15 @@ class ConfigState:
         self.plate_solve_enabled = config_dict.get("plate_solve_enabled", self.plate_solve_enabled)
         self.plate_solve_camera_index = config_dict.get("plate_solve_camera_index", self.plate_solve_camera_index)
         self.alignment_grid_search_cells = config_dict.get("alignment_grid_search_cells", self.alignment_grid_search_cells)
+        self.alignment_settle_tol_deg = config_dict.get("alignment_settle_tol_deg", self.alignment_settle_tol_deg)
+        self.alignment_settle_cycles = config_dict.get("alignment_settle_cycles", self.alignment_settle_cycles)
+        self.alignment_target_rms_arcmin = config_dict.get("alignment_target_rms_arcmin", self.alignment_target_rms_arcmin)
         self.pointing_model_enabled = config_dict.get("pointing_model_enabled", self.pointing_model_enabled)
         if isinstance(config_dict.get("pointing_model_terms"), dict):
             self.pointing_model_terms.update(config_dict["pointing_model_terms"])
+        self.eq_pointing_model_enabled = config_dict.get("eq_pointing_model_enabled", self.eq_pointing_model_enabled)
+        if isinstance(config_dict.get("eq_pointing_model_terms"), dict):
+            self.eq_pointing_model_terms.update(config_dict["eq_pointing_model_terms"])
         self.azm_offset_str = config_dict.get("azm_offset", self.azm_offset_str)
         self.alt_offset_str = config_dict.get("alt_offset", self.alt_offset_str)
 

--- a/control.py
+++ b/control.py
@@ -298,6 +298,24 @@ def apply_pointing_model(config_state, target_az_deg, target_el_deg):
         return target_az_deg, target_el_deg
 
 
+def apply_eq_pointing_model(config_state, target_ha_deg, target_dec_deg):
+    """Correct a desired (hour-angle, dec) through the configured equatorial pointing model.
+
+    Returns the commanded (HA, Dec) to feed the mount transform. A no-op when disabled.
+    The Eq counterpart of apply_pointing_model; applied in HA/Dec space in the Eq branch.
+    """
+    if not getattr(config_state, 'eq_pointing_model_enabled', False):
+        return target_ha_deg, target_dec_deg
+    try:
+        from eq_pointing_model import EquatorialPointingModel
+        lat = float(getattr(config_state, 'lat_str', 0.0) or 0.0)
+        model = EquatorialPointingModel(getattr(config_state, 'eq_pointing_model_terms', None), lat_deg=lat)
+        return model.correct(target_ha_deg, target_dec_deg)
+    except Exception as e:
+        print(f"Eq pointing-model correction skipped: {e}")
+        return target_ha_deg, target_dec_deg
+
+
 def compute_mount_position_error(config_state, current_azm_deg, current_alt_deg, target_az_deg, target_el_deg):
     """
     Compute position error between current mount position and target position.
@@ -317,7 +335,7 @@ def compute_mount_position_error(config_state, current_azm_deg, current_alt_deg,
         tuple: (az_error_deg, el_error_deg) - errors in degrees
     """
     # Check mount mode and use appropriate transformation
-    mount_mode = getattr(config_state, 'mount_mode', 'Eq')
+    mount_mode = getattr(config_state, 'mount_mode', 'AltAz')
 
     if mount_mode == 'AltAz':
         # Import here to avoid circular import
@@ -345,18 +363,21 @@ def compute_mount_position_error(config_state, current_azm_deg, current_alt_deg,
             target_el_deg
         )
     else:
-        # Use full equatorial transformation for Eq mode
-        # Import here to avoid circular import
-        from transformations import local_elev_az_to_telescope #AzEl2AzAlt
-        local_elev_az_to_telescope(target_el_deg, target_az_deg, lat_deg=float(config_state.alignment_elevation_str))
-
-        # Convert target sky position to mount coordinates 
-        # target_azm_deg, target_alt_deg = AzEl2AzAlt(
-        #    target_az_deg,
-        #    target_el_deg,
-        #    float(config_state.alignment_azimuth_str),
-        #    float(config_state.alignment_elevation_str)
-        #)
+        # Equatorial mode: convert the target sky position to mount (hour-angle, dec) axes
+        # for a polar axis pointing at (pole_az, pole_alt). pole_az defaults to due north
+        # (alignment_azimuth) and pole_alt to the site latitude unless an explicit polar-axis
+        # elevation has been entered (alignment_elevation, the "Eq" field in the config UI).
+        from transformations import azel_to_eq_mount
+        pole_az = float(getattr(config_state, 'alignment_azimuth_str', 0.0) or 0.0)
+        pole_alt = float(getattr(config_state, 'alignment_elevation_str', 0.0) or 0.0)
+        if pole_alt == 0.0:
+            pole_alt = float(getattr(config_state, 'lat_str', 0.0) or 0.0)
+        target_ha_deg, target_dec_deg = azel_to_eq_mount(
+            target_az_deg, target_el_deg, pole_az, pole_alt)
+        # Pointing-model pre-step (HA/Dec space): correct the desired axes so the imperfect
+        # mount lands the boresight on target. Kept Python-only, like the AltAz path.
+        target_azm_deg, target_alt_deg = apply_eq_pointing_model(
+            config_state, target_ha_deg, target_dec_deg)
 
     # Compute error in mount coordinates
     azm_error_deg = target_azm_deg - current_azm_deg

--- a/eq_pointing_model.py
+++ b/eq_pointing_model.py
@@ -1,0 +1,208 @@
+"""
+7-term equatorial TPOINT pointing model (the Eq-mode counterpart of pointing_model.py).
+
+Polar alignment removes the gross polar-axis misalignment mechanically, but the mount is
+never perfect: residual axis tilt, axis non-perpendicularity, collimation, index zero-points
+and tube flexure all remain. This model captures them so go-to lands the target after a
+polar-aligned mount is synced. It operates in the mount's hour-angle / declination axes:
+
+    IH - hour-angle index (zero-point) error
+    ID - declination index (zero-point) error
+    NP - HA/Dec axis non-perpendicularity
+    CH - collimation (optical axis vs the Dec axis)
+    ME - polar-axis elevation error (residual after polar align)
+    MA - polar-axis azimuth error    (residual after polar align)
+    TF - tube flexure (gravity sag, toward the horizon)
+
+All coefficients are in degrees. The error (observed minus commanded) as a function of the
+commanded mount position (h, d) and the site latitude phi:
+
+    dHA  = IH + NP*tan(d) + CH*sec(d) + ME*sin(h)*tan(d) - MA*cos(h)*tan(d) + TF*flex_h
+    dDec = ID                          + ME*cos(h)        + MA*sin(h)        + TF*flex_d
+
+The IH/ID/NP/CH/ME/MA basis mirrors the alt-az model (the polar axis plays the role of the
+azimuth axis). Only flexure differs: it is gravity-driven, so it depends on the true altitude
+(zenith distance) and parallactic angle q -- NOT on declination -- and therefore needs the
+latitude. flex_h = cos(el)*sin(q)*sec(d), flex_d = -cos(el)*cos(q), so the great-circle
+flexure magnitude is TF*cos(el) (max near the horizon), exactly like the alt-az TF*cos(E).
+
+Linear in the seven coefficients, so fitting plate-solved samples is one linear least-squares
+solve -- the fit/backtest/robust machinery parallels PointingModel.
+"""
+
+import math
+
+import numpy as np
+
+TERM_NAMES = ("IH", "ID", "NP", "CH", "ME", "MA", "TF")
+
+
+def _wrap180(deg):
+    return (deg + 180.0) % 360.0 - 180.0
+
+
+def _design_rows(h_deg, d_deg, lat_deg):
+    """(row_ha, row_dec): the 7-term basis for the HA and Dec error equations at latitude."""
+    H = math.radians(h_deg)
+    D = math.radians(d_deg)
+    phi = math.radians(lat_deg)
+    tanD = math.tan(D)
+    secD = 1.0 / math.cos(D)
+    # Tube flexure: droop toward the horizon, magnitude cos(el), projected into (HA, Dec)
+    # through the parallactic angle q (needs the true altitude el and q from h, d, phi).
+    sin_el = math.sin(phi) * math.sin(D) + math.cos(phi) * math.cos(D) * math.cos(H)
+    sin_el = max(-1.0, min(1.0, sin_el))
+    cos_el = math.cos(math.asin(sin_el))
+    q = math.atan2(math.sin(H), math.tan(phi) * math.cos(D) - math.sin(D) * math.cos(H))
+    flex_h = cos_el * math.sin(q) * secD
+    flex_d = -cos_el * math.cos(q)
+    # order: IH, ID, NP, CH, ME, MA, TF
+    row_ha = [1.0, 0.0, tanD, secD, math.sin(H) * tanD, -math.cos(H) * tanD, flex_h]
+    row_dec = [0.0, 1.0, 0.0, 0.0, math.cos(H), math.sin(H), flex_d]
+    return row_ha, row_dec
+
+
+class EquatorialPointingModel:
+    """Holds the seven coefficients (and the site latitude for the flexure term)."""
+
+    def __init__(self, terms=None, lat_deg=0.0):
+        self.terms = {k: 0.0 for k in TERM_NAMES}
+        if terms:
+            self.terms.update({k: float(v) for k, v in terms.items() if k in self.terms})
+        self.lat_deg = float(lat_deg)
+
+    @property
+    def _p(self):
+        return np.array([self.terms[k] for k in TERM_NAMES])
+
+    def error(self, h_deg, d_deg):
+        """Pointing error (dHA, dDec) in degrees at a commanded mount position."""
+        row_ha, row_dec = _design_rows(h_deg, d_deg, self.lat_deg)
+        p = self._p
+        return float(np.dot(row_ha, p)), float(np.dot(row_dec, p))
+
+    def predict_observed(self, h_cmd, d_cmd):
+        """Where the boresight lands (HA, Dec) if the mount is commanded to (h_cmd, d_cmd)."""
+        d_ha, d_dec = self.error(h_cmd, d_cmd)
+        return _wrap180(h_cmd + d_ha), d_cmd + d_dec
+
+    def correct(self, h_desired, d_desired):
+        """Command (HA, Dec) to issue so the boresight lands on (h_desired, d_desired).
+
+        First-order inverse (the terms are small): command = desired - error(desired).
+        """
+        d_ha, d_dec = self.error(h_desired, d_desired)
+        return _wrap180(h_desired - d_ha), d_desired - d_dec
+
+    def to_config(self):
+        return dict(self.terms)
+
+    # ---- fitting (parallels pointing_model.PointingModel) -------------------
+    @classmethod
+    def _solve(cls, samples, lat_deg, seed_terms, free_terms):
+        rows, b, cmd = [], [], []
+        for h_cmd, d_cmd, h_obs, d_obs in samples:
+            d_ha = _wrap180(h_obs - h_cmd)
+            d_dec = d_obs - d_cmd
+            row_ha, row_dec = _design_rows(h_cmd, d_cmd, lat_deg)
+            rows.append(row_ha); b.append(d_ha)
+            rows.append(row_dec); b.append(d_dec)
+            cmd.append((h_cmd, d_cmd, d_ha, d_dec))
+
+        A = np.array(rows)
+        b = np.array(b)
+        free_idx = None
+        if free_terms is not None:
+            free_idx = [i for i, k in enumerate(TERM_NAMES) if k in set(free_terms)]
+        if not free_idx:
+            A_used = A
+            coeffs, _, _, _ = np.linalg.lstsq(A, b, rcond=None)
+            model = cls({k: coeffs[i] for i, k in enumerate(TERM_NAMES)}, lat_deg=lat_deg)
+        else:
+            seed = {k: 0.0 for k in TERM_NAMES}
+            if seed_terms:
+                seed.update({k: float(v) for k, v in seed_terms.items() if k in seed})
+            p_fixed = np.array([0.0 if i in free_idx else seed[TERM_NAMES[i]]
+                                for i in range(len(TERM_NAMES))])
+            A_used = A[:, free_idx]
+            c_free, _, _, _ = np.linalg.lstsq(A_used, b - A @ p_fixed, rcond=None)
+            terms = dict(seed)
+            for j, i in enumerate(free_idx):
+                terms[TERM_NAMES[i]] = float(c_free[j])
+            model = cls(terms, lat_deg=lat_deg)
+
+        try:
+            design_cond = float(np.linalg.cond(A_used)) if A_used.size else float('inf')
+        except np.linalg.LinAlgError:
+            design_cond = float('inf')
+        return model, cmd, design_cond
+
+    @classmethod
+    def fit(cls, samples, lat_deg, seed_terms=None, free_terms=None,
+            robust=False, robust_sigma=4.0, robust_floor_deg=30.0 / 3600.0):
+        """Fit a model from samples (h_cmd, d_cmd, h_obs, d_obs) at the given latitude.
+
+        ``free_terms`` enables a partial fit (hold the rest at ``seed_terms``); ``robust``
+        rejects gross-outlier solves (MAD with an absolute floor). Returns (model, stats)
+        with per-term coefficients, n_samples, n_rejected, design_cond, and great-circle sky
+        RMS before/after (HA weighted by cos(dec)).
+        """
+        samples = list(samples)
+
+        def sky_rms(pairs):
+            sq = 0.0
+            for h_cmd, d_cmd, d_ha, d_dec in pairs:
+                cD = math.cos(math.radians(d_cmd))
+                sq += (d_ha * cD) ** 2 + d_dec ** 2
+            return math.sqrt(sq / max(1, len(pairs)))
+
+        def residuals(model, cmd):
+            out = []
+            for h_cmd, d_cmd, d_ha, d_dec in cmd:
+                pr_ha, pr_dec = model.error(h_cmd, d_cmd)
+                out.append((h_cmd, d_cmd, _wrap180(d_ha - pr_ha), d_dec - pr_dec))
+            return out
+
+        model, cmd, design_cond = cls._solve(samples, lat_deg, seed_terms, free_terms)
+        n_rejected = 0
+        MIN_FIT = 4
+        if robust and len(samples) > MIN_FIT:
+            resid = residuals(model, cmd)
+            mags = np.array([math.hypot(d_ha * math.cos(math.radians(d_cmd)), d_dec)
+                             for h_cmd, d_cmd, d_ha, d_dec in resid])
+            med = float(np.median(mags))
+            mad = float(np.median(np.abs(mags - med))) or 1e-9
+            thresh = max(med + robust_sigma * 1.4826 * mad, robust_floor_deg)
+            keep = [s for s, m in zip(samples, mags) if m <= thresh]
+            if MIN_FIT < len(keep) < len(samples):
+                n_rejected = len(samples) - len(keep)
+                samples = keep
+                model, cmd, design_cond = cls._solve(samples, lat_deg, seed_terms, free_terms)
+
+        rms_before = sky_rms(cmd)
+        rms_after = sky_rms(residuals(model, cmd))
+        stats = {
+            "terms": model.to_config(),
+            "lat_deg": lat_deg,
+            "n_samples": len(cmd),
+            "n_rejected": n_rejected,
+            "design_cond": design_cond,
+            "rms_before_deg": rms_before,
+            "rms_after_deg": rms_after,
+            "rms_before_arcmin": rms_before * 60.0,
+            "rms_after_arcmin": rms_after * 60.0,
+        }
+        return model, stats
+
+    def backtest(self, samples):
+        """Great-circle sky RMS (deg) of this model against held-out (h,d,h_obs,d_obs)."""
+        sq = 0.0
+        n = 0
+        for h_cmd, d_cmd, h_obs, d_obs in samples:
+            pr_ha, pr_dec = self.predict_observed(h_cmd, d_cmd)
+            d_ha = _wrap180(h_obs - pr_ha)
+            d_dec = d_obs - pr_dec
+            cD = math.cos(math.radians(d_cmd))
+            sq += (d_ha * cD) ** 2 + d_dec ** 2
+            n += 1
+        return math.sqrt(sq / max(1, n))

--- a/pointing_model.py
+++ b/pointing_model.py
@@ -102,22 +102,14 @@ class PointingModel:
 
     # ---- fitting -----------------------------------------------------------
     @classmethod
-    def fit(cls, samples, remove_refraction=False):
-        """Fit a model from samples.
-
-        samples: iterable of (az_cmd, el_cmd, az_obs, el_obs) in degrees, where *_cmd is
-        the nominal commanded sky position and *_obs is the plate-solved truth.
-
-        Returns (model, stats). stats includes per-term coefficients, the sample count,
-        and sky RMS before/after the fit (great-circle, az weighted by cos(el)).
-        """
-        rows = []
-        b = []
-        cmd = []
+    def _solve(cls, samples, remove_refraction, seed_terms, free_terms):
+        """Core least-squares solve for a fixed sample set. Returns
+        (model, cmd, design_cond) where ``cmd`` is the per-sample (az, el, d_az, d_el)
+        raw-error list and ``design_cond`` is the condition number of the (free) design
+        matrix -- a high value flags an ill-posed grid (terms the points can't separate)."""
+        rows, b, cmd = [], [], []
         for az_cmd, el_cmd, az_obs, el_obs in samples:
-            el_obs_geo = el_obs
-            if remove_refraction:
-                el_obs_geo = el_obs - bennett_refraction_deg(el_obs)
+            el_obs_geo = el_obs - bennett_refraction_deg(el_obs) if remove_refraction else el_obs
             d_az = _wrap180(az_obs - az_cmd)
             d_el = el_obs_geo - el_cmd
             row_az, row_el = _design_rows(az_cmd, el_cmd)
@@ -127,10 +119,61 @@ class PointingModel:
 
         A = np.array(rows)
         b = np.array(b)
-        coeffs, _, _, _ = np.linalg.lstsq(A, b, rcond=None)
-        model = cls({k: coeffs[i] for i, k in enumerate(TERM_NAMES)})
 
-        # RMS before (raw error) and after (residual), great-circle.
+        free_idx = None
+        if free_terms is not None:
+            free_idx = [i for i, k in enumerate(TERM_NAMES) if k in set(free_terms)]
+        if not free_idx:  # full fit (free_terms None, empty, or unrecognised)
+            A_used = A
+            coeffs, _, _, _ = np.linalg.lstsq(A, b, rcond=None)
+            model = cls({k: coeffs[i] for i, k in enumerate(TERM_NAMES)})
+        else:
+            # Partial fit: hold the non-free terms at their seed values and solve only the
+            # free columns against the residual error they don't explain.
+            seed = {k: 0.0 for k in TERM_NAMES}
+            if seed_terms:
+                seed.update({k: float(v) for k, v in seed_terms.items() if k in seed})
+            p_fixed = np.array([0.0 if i in free_idx else seed[TERM_NAMES[i]] for i in range(len(TERM_NAMES))])
+            A_used = A[:, free_idx]
+            c_free, _, _, _ = np.linalg.lstsq(A_used, b - A @ p_fixed, rcond=None)
+            terms = dict(seed)
+            for j, i in enumerate(free_idx):
+                terms[TERM_NAMES[i]] = float(c_free[j])
+            model = cls(terms)
+
+        try:
+            design_cond = float(np.linalg.cond(A_used)) if A_used.size else float('inf')
+        except np.linalg.LinAlgError:
+            design_cond = float('inf')
+        return model, cmd, design_cond
+
+    @classmethod
+    def fit(cls, samples, remove_refraction=False, seed_terms=None, free_terms=None,
+            robust=False, robust_sigma=4.0, robust_floor_deg=30.0 / 3600.0):
+        """Fit a model from samples.
+
+        samples: iterable of (az_cmd, el_cmd, az_obs, el_obs) in degrees, where *_cmd is
+        the nominal commanded sky position and *_obs is the plate-solved truth.
+
+        ``free_terms`` enables a *partial* (nightly-refresh) fit: only the named terms are
+        solved for, the rest are held fixed at ``seed_terms`` (the previous night's model).
+        The mount's mechanical terms (AN/AW/NPAE/CA/TF) are stable across nights -- only the
+        index errors IA/IE drift with re-leveling/re-homing -- so seeding from last night
+        and refitting just ``["IA", "IE"]`` reaches a good model with a handful of points.
+        When ``free_terms`` is None all seven terms are fit (the full alignment).
+
+        ``robust`` does a second pass that rejects samples whose post-fit sky residual
+        exceeds BOTH ``robust_sigma`` * (MAD-scaled) sigma AND ``robust_floor_deg`` (an
+        absolute floor so tight, clean fits never reject good points), then re-fits on the
+        survivors -- so a single bad plate solve (a mis-match, a satellite/plane in the field)
+        can't drag the whole model. Skipped if it would drop below the minimum fittable count.
+
+        Returns (model, stats). stats includes per-term coefficients, the sample count, the
+        design-matrix condition number, the number of rejected samples (robust), and sky RMS
+        before/after the fit (great-circle, az weighted by cos(el)).
+        """
+        samples = list(samples)
+
         def sky_rms(pairs):
             sq = 0.0
             for az_cmd, el_cmd, d_az, d_el in pairs:
@@ -138,16 +181,38 @@ class PointingModel:
                 sq += (d_az * cE) ** 2 + d_el ** 2
             return math.sqrt(sq / max(1, len(pairs)))
 
+        def residuals(model, cmd):
+            out = []
+            for az_cmd, el_cmd, d_az, d_el in cmd:
+                pr_az, pr_el = model.error(az_cmd, el_cmd)
+                out.append((az_cmd, el_cmd, _wrap180(d_az - pr_az), d_el - pr_el))
+            return out
+
+        model, cmd, design_cond = cls._solve(samples, remove_refraction, seed_terms, free_terms)
+        n_rejected = 0
+        MIN_FIT = 4  # below this a 7-term (or even 2-term) fit is meaningless
+        if robust and len(samples) > MIN_FIT:
+            resid = residuals(model, cmd)
+            # Per-sample sky residual magnitude (same great-circle metric as sky_rms).
+            mags = np.array([math.hypot(d_az * math.cos(math.radians(el_cmd)), d_el)
+                             for az_cmd, el_cmd, d_az, d_el in resid])
+            med = float(np.median(mags))
+            mad = float(np.median(np.abs(mags - med))) or 1e-9
+            thresh = max(med + robust_sigma * 1.4826 * mad, robust_floor_deg)
+            keep = [s for s, m in zip(samples, mags) if m <= thresh]
+            if MIN_FIT < len(keep) < len(samples):
+                n_rejected = len(samples) - len(keep)
+                samples = keep
+                model, cmd, design_cond = cls._solve(samples, remove_refraction, seed_terms, free_terms)
+
         rms_before = sky_rms(cmd)
-        resid = []
-        for az_cmd, el_cmd, d_az, d_el in cmd:
-            pr_az, pr_el = model.error(az_cmd, el_cmd)
-            resid.append((az_cmd, el_cmd, _wrap180(d_az - pr_az), d_el - pr_el))
-        rms_after = sky_rms(resid)
+        rms_after = sky_rms(residuals(model, cmd))
 
         stats = {
             "terms": model.to_config(),
             "n_samples": len(cmd),
+            "n_rejected": n_rejected,
+            "design_cond": design_cond,
             "rms_before_deg": rms_before,
             "rms_after_deg": rms_after,
             "rms_before_arcmin": rms_before * 60.0,

--- a/polar_align.py
+++ b/polar_align.py
@@ -1,0 +1,277 @@
+"""
+Plate-solve polar alignment for the equatorial (Eq) mount mode.
+
+The fast dusk-time tool for field-rotation-free imaging: instead of a full pointing-model
+grid, rotate ONLY the RA (hour-angle / AZM) axis through a few positions, plate-solve each,
+and fit the physical RA-axis direction from where the boresight lands. The angle between
+that axis and the true celestial pole is the polar-alignment error, reported as the
+azimuth/altitude knob corrections the operator dials out -- the same method SharpCap/NINA use.
+
+Why it works: with the Dec axis held fixed and only the RA axis turning, the boresight sweeps
+a circle about the physical RA axis. Converting each plate solve (RA/Dec) to horizontal
+(az, el) AT ITS SOLVE TIME gives the tube's instantaneous physical direction (sky rotation
+doesn't move an idle tube), so the samples lie on that circle and their best-fit plane normal
+is the RA-axis direction. No precise knowledge of the rotation amounts is needed.
+
+The routine only MEASURES the error (for the operator to null mechanically); it does not feed
+the tracking transform. Sampling is decoupled from hardware through an injected sampler so it
+runs headlessly against the sim (sim_pole_*_err_deg) and in the GUI against the real
+slew + plate-solve path.
+"""
+
+import math
+import threading
+import time
+
+import numpy as np
+
+from transformations import cartesian_from_az_el, az_el_from_cartesian
+
+IDLE = "idle"
+RUNNING = "running"
+DONE = "done"
+ERROR = "error"
+
+MIN_SAMPLES = 3  # need >=3 non-collinear points to define the circle / its axis
+
+
+def _wrap180(deg):
+    return (deg + 180.0) % 360.0 - 180.0
+
+
+def fit_polar_axis(samples_azel, toward_az_deg=0.0, toward_alt_deg=45.0):
+    """Best-fit RA-axis direction (az, el) from boresight samples on a circle.
+
+    ``samples_azel`` is a list of (az, el) horizontal directions the boresight swept while
+    only the RA axis turned. Returns (axis_az_deg, axis_el_deg). The axis is the normal to
+    the best-fit plane through the points (SVD), oriented toward (toward_az, toward_alt) so
+    it names the pole-side end of the axis rather than its antipode.
+    """
+    pts = np.array([cartesian_from_az_el(az, el) for az, el in samples_azel])
+    if len(pts) < MIN_SAMPLES:
+        raise ValueError("need at least 3 samples to fit the polar axis")
+    centroid = pts.mean(axis=0)
+    # Smallest right-singular vector of the centered points = best-fit plane normal.
+    _, _, vt = np.linalg.svd(pts - centroid)
+    axis = vt[-1]
+    axis = axis / np.linalg.norm(axis)
+    if np.dot(axis, cartesian_from_az_el(toward_az_deg, toward_alt_deg)) < 0:
+        axis = -axis
+    return az_el_from_cartesian(axis)
+
+
+def polar_error(measured_az, measured_alt, target_az, target_alt):
+    """Polar-axis error and the correction to apply.
+
+    Returns a dict: az_error/alt_error (measured minus target, degrees; az wrapped to
+    +-180), total_deg (great-circle angle between the measured axis and the true pole), and
+    az_move/alt_move (the correction = -error) with human-readable directions. Positive
+    az_error means the polar axis points too far EAST; positive alt_error means too HIGH.
+    """
+    az_err = _wrap180(measured_az - target_az)
+    alt_err = measured_alt - target_alt
+    a = cartesian_from_az_el(measured_az, measured_alt)
+    b = cartesian_from_az_el(target_az, target_alt)
+    total = math.degrees(math.acos(max(-1.0, min(1.0, float(np.dot(a, b))))))
+    return {
+        "az_error": az_err,
+        "alt_error": alt_err,
+        "total_deg": total,
+        "az_move": -az_err,
+        "alt_move": -alt_err,
+        "az_dir": "west" if az_err > 0 else "east",
+        "alt_dir": "down" if alt_err > 0 else "up",
+    }
+
+
+class PolarAlignState:
+    """Mutable state for a polar-alignment run, read by the UI each frame."""
+
+    def __init__(self):
+        self.phase = IDLE
+        self.samples = []          # (az_obs, el_obs) boresight directions
+        self.sample_meta = []      # per-sample dict (azm command, solve quality)
+        self.measured_pole = None  # (az, el) of the fitted RA axis
+        self.result = None         # polar_error() dict
+        self.status = ""
+        self.error = None
+        self.progress = (0, 0)
+        self.current_target = None  # (azm, alt) the runner is slewing to
+        self.last_solve = None
+
+    def reset(self):
+        self.__init__()
+
+
+class PolarAlignRunner(threading.Thread):
+    """Rotate the RA (AZM) axis through a span, plate-solve each step, fit the axis.
+
+    ``sampler`` exposes ``slew(azm_deg, alt_deg) -> bool`` (drive the mount axes) and
+    ``capture() -> (az_obs, el_obs, meta) | None`` (plate-solve the current frame, sky az/el
+    at solve time). ``target_az``/``target_alt`` are the true celestial-pole direction
+    (north/south azimuth, latitude). The Dec axis is parked at ``dec_deg`` and the RA axis
+    stepped across ``ha_span_deg`` (centred on 0) in ``n_points`` steps.
+    """
+
+    def __init__(self, state, config_state, sampler, target_az, target_alt,
+                 n_points=5, dec_deg=20.0, ha_span_deg=80.0, status_cb=None):
+        super().__init__(daemon=True)
+        self.s = state
+        self.config_state = config_state
+        self.sampler = sampler
+        self.target_az = float(target_az)
+        self.target_alt = float(target_alt)
+        self.n_points = max(MIN_SAMPLES, int(n_points))
+        self.dec_deg = float(dec_deg)
+        self.ha_span_deg = float(ha_span_deg)
+        self.status_cb = status_cb
+        self._abort = threading.Event()
+
+    def abort(self):
+        self._abort.set()
+
+    def _status(self, msg):
+        self.s.status = msg
+        if self.status_cb:
+            self.status_cb(msg)
+
+    def _ha_steps(self):
+        half = self.ha_span_deg / 2.0
+        if self.n_points == 1:
+            return [0.0]
+        return [(-half + i * self.ha_span_deg / (self.n_points - 1)) for i in range(self.n_points)]
+
+    def run(self):
+        s = self.s
+        try:
+            s.phase = RUNNING
+            steps = self._ha_steps()
+            for i, ha in enumerate(steps):
+                if self._abort.is_set():
+                    s.phase = IDLE
+                    self._status("aborted")
+                    return
+                s.progress = (i, len(steps))
+                s.current_target = (ha, self.dec_deg)
+                self._status(f"step {i + 1}/{len(steps)}  HA {ha:+.0f}°")
+                self.sampler.slew(ha, self.dec_deg)
+                smp = self.sampler.capture()
+                if smp is not None:
+                    s.samples.append((smp[0] % 360.0, smp[1]))
+                    s.sample_meta.append(dict(smp[2] or {}, ha=ha))
+                    s.last_solve = smp[2]
+            s.progress = (len(steps), len(steps))
+
+            if len(s.samples) < MIN_SAMPLES:
+                s.phase = ERROR
+                s.error = (f"only {len(s.samples)} solves (need {MIN_SAMPLES}); "
+                           "check stars/clouds/DB and retry")
+                self._status(s.error)
+                return
+
+            az_m, alt_m = fit_polar_axis(s.samples, self.target_az, self.target_alt)
+            s.measured_pole = (az_m, alt_m)
+            s.result = polar_error(az_m, alt_m, self.target_az, self.target_alt)
+            s.current_target = None
+            s.phase = DONE
+            r = s.result
+            self._status(
+                f"done: polar error {r['total_deg']:.2f}°  "
+                f"(az {abs(r['az_error']):.2f}° {r['az_dir']}, "
+                f"alt {abs(r['alt_error']):.2f}° {r['alt_dir']})")
+        except Exception as e:
+            s.current_target = None
+            s.phase = ERROR
+            s.error = str(e)
+            self._status(f"error: {e}")
+
+
+class PolarGuiSampler:
+    """Live sampler: drive the mount AZM/ALT axes directly and plate-solve the result.
+
+    Mirrors alignment.GuiSampler but commands mount axes (HA/Dec) instead of sky az/el, and
+    returns the solved sky az/el at solve time (the boresight's instantaneous direction).
+    """
+
+    def __init__(self, joystick_state, config_state, solver, ts, ephemeris,
+                 cam_index=0, settle_pause=0.4, state=None):
+        self.joystick_state = joystick_state
+        self.config_state = config_state
+        self.solver = solver
+        self.ts = ts
+        self.ephemeris = ephemeris
+        self.cam_index = cam_index
+        self.settle_pause = settle_pause
+        self.state = state
+
+    def slew(self, azm_deg, alt_deg):
+        from alignment import _wrap180 as _w  # reuse the settle helper's wrap
+        from lib.auxstar import Targets
+        controller = getattr(self.joystick_state, 'telescope_controller', None)
+        if controller is None:
+            return False
+        cfg = self.config_state
+        tol = float(getattr(cfg, 'alignment_settle_tol_deg', 0.3) or 0.3)
+        cycles = int(getattr(cfg, 'alignment_settle_cycles', 2) or 2)
+        kp, max_dps, timeout = 4.0, 5.0, 20.0
+        use_rate = hasattr(controller, 'hc_set_rate_dps')
+        try:
+            controller.hc_goto_fast(Targets.AZM, azm_deg, 0, 0)
+            controller.hc_goto_fast(Targets.ALT, alt_deg, 0, 0)
+        except Exception:
+            pass
+
+        def cmd(target, err):
+            if use_rate:
+                controller.hc_set_rate_dps(target, max(-max_dps, min(max_dps, kp * err)))
+
+        def stop():
+            if use_rate:
+                controller.hc_set_rate_dps(Targets.AZM, 0.0)
+                controller.hc_set_rate_dps(Targets.ALT, 0.0)
+
+        t0 = time.time(); stable = 0
+        while time.time() - t0 < timeout:
+            e_az = _w(azm_deg - controller.hc_get_position(Targets.AZM) * 360.0)
+            e_alt = _w(alt_deg - controller.hc_get_position(Targets.ALT) * 360.0)
+            if abs(e_az) < tol and abs(e_alt) < tol:
+                stable += 1
+                if stable >= cycles:
+                    stop(); break
+            else:
+                stable = 0
+                cmd(Targets.AZM, e_az); cmd(Targets.ALT, e_alt)
+            time.sleep(0.05)
+        else:
+            stop()
+        time.sleep(self.settle_pause)
+        return True
+
+    def capture(self):
+        import camera_manager
+        import plate_solver as ps_mod
+        camera = camera_manager.camera_manager.get_camera(self.cam_index)
+        raw = (camera.thread.get_latest_raw()
+               if camera is not None and getattr(camera, 'thread', None) is not None else None)
+        if raw is None:
+            return None
+        t = self.ts.now()
+        result = self.solver.solve(raw)
+        if result is None or not result.solved:
+            return None
+        cfg = self.config_state
+        lat = float(cfg.lat_str or 0.0); lon = float(cfg.lon_str or 0.0)
+        elev = float(cfg.alt_str or 0.0)
+        az_obs, el_obs = ps_mod.solved_azel(result.ra_deg, result.dec_deg, lat, lon, elev,
+                                            self.ephemeris, self.ts, t)
+        meta = {'result': result, 'n_matches': result.n_matches, 'rmse': result.rmse,
+                'fov': result.fov_deg, 't': t}
+        if self.state is not None:
+            self.state.last_solve = meta
+        return (az_obs % 360.0, el_obs, meta)
+
+
+def make_polar_sampler(joystick_state, config_state, solver, ts, ephemeris,
+                       cam_index=0, state=None):
+    return PolarGuiSampler(joystick_state, config_state, solver, ts, ephemeris,
+                           cam_index, state=state)

--- a/simulator.py
+++ b/simulator.py
@@ -131,6 +131,30 @@ def add_noise(frame, read_noise, rng):
     np.clip(frame, 0, None, out=frame)
 
 
+def injected_boresight(config_state, nominal_az_deg, nominal_el_deg):
+    """Where the boresight ACTUALLY lands on the sky (what a plate solve sees) when the
+    mount's encoders nominally read sky (az, el), given the sim's injected error sources.
+
+    Models, in order: the repeatable 7-term alt-az pointing model
+    (``sim_config['mount_pointing_model']``) via PointingModel.predict_observed, then
+    atmospheric refraction (``sim_config['sim_refraction']``) which lifts the apparent
+    elevation. A no-op (returns the input) when neither is configured. This is the inverse
+    problem the alignment routine solves -- injecting it here lets a sim alignment run
+    recover all seven terms end-to-end (not just the encoder-bias IA/IE)."""
+    s = getattr(config_state, 'sim_config', {}) or {}
+    az, el = float(nominal_az_deg), float(nominal_el_deg)
+    terms = s.get('mount_pointing_model') or None
+    if terms and any(abs(float(v)) > 0.0 for v in terms.values()):
+        from pointing_model import PointingModel
+        az, el = PointingModel(terms).predict_observed(az, el)
+    if s.get('sim_refraction', False):
+        from pointing_model import bennett_refraction_deg
+        p = float(s.get('sim_refraction_pressure_mbar', 1010.0))
+        t = float(s.get('sim_refraction_temperature_c', 10.0))
+        el = el + bennett_refraction_deg(el, p, t)  # apparent elevation is higher than geometric
+    return az % 360.0, el
+
+
 # ---------------------------------------------------------------------------
 # Sim mount
 # ---------------------------------------------------------------------------
@@ -480,10 +504,31 @@ class HardwareSimulator:
             cam_az, cam_el = self.mount.az_true_deg, self.mount.el_true_deg
             sky_az_rate, sky_el_rate = self.mount.az_rate_dps, self.mount.el_rate_dps
         else:
-            from transformations import AzAlt2AzEl
-            cam_az, cam_el = AzAlt2AzEl(
-                self.mount.az_true_deg, self.mount.el_true_deg, align_az, align_el)
+            # Equatorial: mount AZM=hour angle, ALT=declination, rotating about the TRUE
+            # polar axis. The sim's true pole can be mis-set (sim_pole_az/alt_err) so a
+            # polar-alignment run has a real error to measure; it defaults to the assumed
+            # pole (north, latitude) -> perfect alignment.
+            from transformations import eq_mount_to_azel
+            lat = float(getattr(cfg, 'lat_str', 0.0) or 0.0)
+            true_pole_az = align_az + float(s.get('sim_pole_az_err_deg', 0.0))
+            base_alt = align_el if align_el != 0.0 else lat
+            true_pole_alt = base_alt + float(s.get('sim_pole_alt_err_deg', 0.0))
+            # Residual mount errors (cone/index/flexure) on top of the polar misalignment:
+            # distort the mount HA/Dec by the injected equatorial model before the pole geometry.
+            h_m, d_m = self.mount.az_true_deg, self.mount.el_true_deg
+            eqterms = s.get('mount_eq_pointing_model') or None
+            if eqterms and any(abs(float(v)) > 0.0 for v in eqterms.values()):
+                from eq_pointing_model import EquatorialPointingModel
+                h_m, d_m = EquatorialPointingModel(eqterms, lat_deg=lat).predict_observed(h_m, d_m)
+            cam_az, cam_el = eq_mount_to_azel(h_m, d_m, true_pole_az, true_pole_alt)
             sky_az_rate, sky_el_rate = self.mount.az_rate_dps, self.mount.el_rate_dps
+
+        # Inject the repeatable pointing-model + refraction error (alt-az only): the boresight
+        # actually lands where predict_observed() says, so the whole rendered field shifts by
+        # the pointing error and an alignment run can recover the seven terms end-to-end.
+        if mount_mode == 'AltAz':
+            cam_az, cam_el = injected_boresight(cfg, cam_az, cam_el)
+
         cx, cy = w / 2.0 + off_x, h / 2.0 + off_y
 
         brightness = float(s.get('target_brightness', 200.0))

--- a/test_alignment.py
+++ b/test_alignment.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from config import ConfigState
 from pointing_model import PointingModel
+import alignment as al
 from alignment import AlignmentState, AlignmentRunner, accept_alignment, slew_to_azel, DONE
 from simulator import SimMount
 from transformations import AzEl2AzAlt_AltAz
@@ -68,6 +69,23 @@ class TestAlignmentRunner(unittest.TestCase):
         for k, v in TRUTH.items():
             self.assertAlmostEqual(cfg.pointing_model_terms[k], v, delta=0.01)
 
+    def test_early_stop_halts_before_full_grid(self):
+        """With a target RMS set, a clean fit should stop sampling well before the whole
+        grid is consumed, yet still recover the model."""
+        cfg = ConfigState()
+        cfg.mount_mode = 'AltAz'
+        cfg.elevation_mask_str = '10.0'
+        state = AlignmentState()
+        runner = AlignmentRunner(state, cfg, self._synthetic_sample_fn(noise_arcsec=0.0),
+                                 n_points=40, holdout_frac=0.25, target_rms_arcmin=0.5)
+        runner.run()
+        self.assertEqual(state.phase, DONE, state.error)
+        # Stopped early: far fewer fit samples than the available fit points.
+        self.assertLess(len(state.samples), len(state.fit_points))
+        self.assertLessEqual(len(state.samples), 20)
+        for k, v in TRUTH.items():
+            self.assertAlmostEqual(state.model.terms[k], v, delta=0.05)
+
     def test_holdout_disjoint_from_fit(self):
         cfg = ConfigState()
         state = AlignmentState()
@@ -77,6 +95,143 @@ class TestAlignmentRunner(unittest.TestCase):
         hold_set = set(state.holdout_points)
         self.assertTrue(fit_set.isdisjoint(hold_set))
         self.assertGreater(len(hold_set), 0)
+
+
+class _SimSolveSampler:
+    """Live-style sampler (slew + capture) backed by SimMount + the sim's injected pointing
+    model, bypassing the camera/plate-solve so the test is deterministic and tetra3-free but
+    still drives the REAL closed-loop slew (slew_to_azel) and the AlignmentRunner live path.
+    Closes the 'sim only recovers IA/IE' gap: with a full injected model it recovers all 7."""
+
+    def __init__(self, config_state, mount, fov_deg=1.0):
+        self.config_state = config_state
+        self.mount = mount
+        self.fov_deg = fov_deg
+
+    def slew(self, az, el):
+        return slew_to_azel(self.mount, self.config_state, az, el,
+                            timeout=8.0, tol_deg=0.1, settle_cycles=2)
+
+    def capture(self):
+        from lib.auxstar import Targets
+        from transformations import AzAlt2AzEl_AltAz
+        from simulator import injected_boresight
+        align_az = float(self.config_state.alignment_azimuth_str or 0.0)
+        cur_azm = self.mount.hc_get_position(Targets.AZM) * 360.0
+        cur_alt = self.mount.hc_get_position(Targets.ALT) * 360.0
+        az_cmd, el_cmd = AzAlt2AzEl_AltAz(cur_azm, cur_alt, align_az)
+        az_obs, el_obs = injected_boresight(self.config_state, az_cmd, el_cmd)
+        return (az_cmd % 360.0, el_cmd, az_obs % 360.0, el_obs,
+                {'kind': 'fit', 'n_matches': 12, 'rmse': 0.05, 'fov': self.fov_deg})
+
+    def set_manual(self, on):
+        pass
+
+
+class TestSimMountEndToEnd(unittest.TestCase):
+    """Full pointing model recovered through the real SimMount + slew loop + orchestration."""
+
+    def _cfg(self):
+        cfg = ConfigState()
+        cfg.mount_mode = 'AltAz'
+        cfg.alignment_azimuth_str = '0.0'
+        cfg.alignment_elevation_str = '0.0'
+        cfg.elevation_mask_str = '10.0'
+        cfg.sim_config['mount_misalignment_az_deg'] = 0.0
+        cfg.sim_config['mount_misalignment_el_deg'] = 0.0
+        cfg.sim_config['mount_encoder_noise_deg'] = 0.0
+        return cfg
+
+    def test_recovers_full_injected_model(self):
+        cfg = self._cfg()
+        cfg.sim_config['mount_pointing_model'] = dict(TRUTH)
+        mount = SimMount(cfg)
+        state = AlignmentState()
+        runner = AlignmentRunner(state, cfg, _SimSolveSampler(cfg, mount),
+                                 n_points=18, holdout_frac=0.25)
+        runner.run()
+        self.assertEqual(state.phase, DONE, state.error)
+        self.assertLess(state.stats['rms_after_arcmin'], 0.5)
+        for k, v in TRUTH.items():
+            self.assertAlmostEqual(state.model.terms[k], v, delta=0.05)
+        self.assertIsNotNone(state.backtest_rms_deg)
+        self.assertLess(state.backtest_rms_deg * 60.0, 1.0)
+
+    def test_refraction_removed_beats_not_removed(self):
+        cfg = self._cfg()
+        cfg.sim_config['mount_pointing_model'] = {}
+        cfg.sim_config['sim_refraction'] = True
+        mount = SimMount(cfg)
+        state = AlignmentState()
+        # el_min lifted so refraction stays modest (and the geometric model ~ identity).
+        runner = AlignmentRunner(state, cfg, _SimSolveSampler(cfg, mount),
+                                 n_points=18, holdout_frac=0.25, el_min=30.0,
+                                 remove_refraction=True)
+        runner.run()
+        self.assertEqual(state.phase, DONE, state.error)
+        # Stripping refraction recovers a near-identity geometric model.
+        self.assertLess(state.stats['rms_after_arcmin'], 0.5)
+        # Same samples fit WITHOUT removing refraction leave a larger residual (refraction's
+        # cot(el) shape isn't in the geometric basis).
+        _, st_keep = PointingModel.fit(state.samples, remove_refraction=False)
+        self.assertGreater(st_keep['rms_after_arcmin'], state.stats['rms_after_arcmin'])
+
+
+class _SimEqSampler:
+    """Eq live-style sampler: slews map sky (az,el) -> mount (HA,Dec) about the assumed pole,
+    and capture returns (h_cmd, d_cmd, h_obs, d_obs) with the boresight distorted by an
+    injected equatorial pointing model. Deterministic, tetra3-free."""
+
+    fov_deg = 1.0
+
+    def __init__(self, config_state, truth_model):
+        self.config_state = config_state
+        self.truth = truth_model
+        self._h = 0.0
+        self._d = 0.0
+
+    def slew(self, az, el):
+        from transformations import azel_to_eq_mount
+        pole_az, pole_alt = al._assumed_pole(self.config_state)
+        self._h, self._d = azel_to_eq_mount(az, el, pole_az, pole_alt)
+        return True
+
+    def capture(self):
+        h_obs, d_obs = self.truth.predict_observed(self._h, self._d)
+        return (self._h, self._d, h_obs, d_obs, {'kind': 'fit', 'n_matches': 12})
+
+    def set_manual(self, on):
+        pass
+
+
+class TestEqAlignmentEndToEnd(unittest.TestCase):
+    """The equatorial pointing model is recovered through the alignment orchestration."""
+
+    def test_recovers_eq_model(self):
+        from eq_pointing_model import EquatorialPointingModel
+        lat = 42.0
+        truth = {"IH": 0.5, "ID": -0.3, "NP": 0.04, "CH": 0.06, "ME": 0.03, "MA": -0.05, "TF": 0.08}
+        cfg = ConfigState()
+        cfg.mount_mode = 'Eq'
+        cfg.lat_str = str(lat)
+        cfg.alignment_azimuth_str = '0.0'
+        cfg.alignment_elevation_str = '0.0'
+        cfg.elevation_mask_str = '10.0'
+        state = AlignmentState()
+        sampler = _SimEqSampler(cfg, EquatorialPointingModel(truth, lat_deg=lat))
+        runner = AlignmentRunner(state, cfg, sampler, n_points=30, holdout_frac=0.25)
+        self.assertTrue(runner.eq_mode)
+        runner.run()
+        self.assertEqual(state.phase, DONE, state.error)
+        self.assertIsInstance(state.model, EquatorialPointingModel)
+        for k, v in truth.items():
+            self.assertAlmostEqual(state.model.terms[k], v, delta=0.05, msg=k)
+        # accept_alignment writes the EQUATORIAL config (not the alt-az terms).
+        accept_alignment(state, cfg, save=False)
+        self.assertTrue(cfg.eq_pointing_model_enabled)
+        self.assertFalse(cfg.pointing_model_enabled)
+        for k, v in truth.items():
+            self.assertAlmostEqual(cfg.eq_pointing_model_terms[k], v, delta=0.05)
 
 
 class TestSlewSettle(unittest.TestCase):

--- a/test_alignment_supervised.py
+++ b/test_alignment_supervised.py
@@ -85,6 +85,24 @@ class TestObjectSamplerPath(unittest.TestCase):
         self.assertEqual(len(state.samples), len(state.fit_points))
 
 
+class TestSolveFailures(unittest.TestCase):
+    def test_total_solve_failure_errors_gracefully(self):
+        """When nothing solves (clouds / wrong DB / no stars) and grid search is disabled,
+        the run fails cleanly with a helpful message and every point is retryable -- it must
+        not crash or fit garbage."""
+        from alignment import ERROR
+        state = AlignmentState()
+        state.pause_on_fail = False
+        sampler = FakeSampler(fail_until=10_000)  # never solves
+        runner = AlignmentRunner(state, _cfg(), sampler, n_points=20, grid_cells=0)
+        runner.run()
+        self.assertEqual(state.phase, ERROR)
+        self.assertIsNone(state.model)
+        self.assertLess(len(state.samples), MIN_SAMPLES)
+        self.assertGreater(len(state.failed_points), 0)
+        self.assertIn("failed", state.error)
+
+
 class TestRetryFailed(unittest.TestCase):
     def test_failed_point_then_retry_appends_and_refits(self):
         # With a 12-cell grid search, fail the nominal + all 12 grid offsets of point 1

--- a/test_eq_pointing_model.py
+++ b/test_eq_pointing_model.py
@@ -1,0 +1,118 @@
+"""
+Equatorial 7-term pointing model (eq_pointing_model.py): the least-squares fit recovers
+injected TPOINT coefficients in hour-angle/dec space, the correct/observe inverse holds,
+robust rejection drops a blunder, and the control-loop Eq correction is wired (apply ==
+model.correct, and the mount-position error vanishes at the corrected command).
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+from eq_pointing_model import EquatorialPointingModel, TERM_NAMES
+from config import ConfigState
+from control import apply_eq_pointing_model, compute_mount_position_error
+
+LAT = 42.0
+TRUTH = {"IH": 0.5, "ID": -0.3, "NP": 0.04, "CH": 0.06, "ME": 0.03, "MA": -0.05, "TF": 0.08}
+
+
+def _grid_hd():
+    return [(h, d) for h in range(-80, 81, 20) for d in range(-10, 71, 20)]
+
+
+def _samples(model, grid, noise_arcsec=0.0, seed=0):
+    rng = np.random.default_rng(seed)
+    out = []
+    for h, d in grid:
+        h_obs, d_obs = model.predict_observed(h, d)
+        if noise_arcsec:
+            n = noise_arcsec / 3600.0
+            h_obs += rng.normal(0, n) / max(0.2, math.cos(math.radians(d)))
+            d_obs += rng.normal(0, n)
+        out.append((h, d, h_obs, d_obs))
+    return out
+
+
+class TestEqModelFit(unittest.TestCase):
+    def test_recovers_injected_terms_noiseless(self):
+        truth = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        model, stats = EquatorialPointingModel.fit(_samples(truth, _grid_hd()), LAT)
+        for k in TERM_NAMES:
+            self.assertAlmostEqual(model.terms[k], TRUTH[k], delta=1e-3, msg=k)
+        self.assertLess(stats["rms_after_arcmin"], 0.05)
+        self.assertIn("design_cond", stats)
+
+    def test_recovers_with_noise(self):
+        truth = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        model, stats = EquatorialPointingModel.fit(
+            _samples(truth, _grid_hd(), noise_arcsec=10.0, seed=2), LAT)
+        for k in TERM_NAMES:
+            self.assertAlmostEqual(model.terms[k], TRUTH[k], delta=0.05, msg=k)
+
+    def test_correct_then_observe_is_identity(self):
+        truth = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        for h, d in [(0, 20), (45, -10), (-60, 55)]:
+            h_cmd, d_cmd = truth.correct(h, d)
+            h_obs, d_obs = truth.predict_observed(h_cmd, d_cmd)
+            self.assertLess(abs(((h_obs - h + 180) % 360 - 180)) * math.cos(math.radians(d)), 0.01)
+            self.assertLess(abs(d_obs - d), 0.01)
+
+    def test_robust_rejects_outlier(self):
+        truth = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        samples = _samples(truth, _grid_hd(), noise_arcsec=8.0, seed=4)
+        bad = list(samples[5]); bad[2] += 2.0; bad[3] += 2.0
+        samples[5] = tuple(bad)
+        naive, st_n = EquatorialPointingModel.fit(samples, LAT, robust=False)
+        robust, st_r = EquatorialPointingModel.fit(samples, LAT, robust=True)
+        # The blunder is rejected (a high-leverage 2 deg outlier can also swamp a few clean
+        # neighbours into rejection -- harmless with 45 points; the point is a far better fit).
+        self.assertGreaterEqual(st_r["n_rejected"], 1)
+        self.assertLess(st_r["rms_after_arcmin"], st_n["rms_after_arcmin"])
+        for k in TERM_NAMES:
+            self.assertAlmostEqual(robust.terms[k], TRUTH[k], delta=0.05, msg=k)
+
+    def test_flexure_depends_on_latitude(self):
+        # The TF basis is latitude-dependent (gravity), unlike the other terms.
+        m_lo = EquatorialPointingModel({"TF": 0.1}, lat_deg=20.0)
+        m_hi = EquatorialPointingModel({"TF": 0.1}, lat_deg=60.0)
+        self.assertNotAlmostEqual(m_lo.error(40, 10)[1], m_hi.error(40, 10)[1], places=4)
+
+
+class TestEqControlIntegration(unittest.TestCase):
+    def _cfg(self):
+        cfg = ConfigState()
+        cfg.mount_mode = 'Eq'
+        cfg.lat_str = str(LAT)
+        cfg.alignment_azimuth_str = '0.0'
+        cfg.alignment_elevation_str = '0.0'  # pole_alt falls back to latitude
+        cfg.eq_pointing_model_enabled = True
+        cfg.eq_pointing_model_terms = dict(TRUTH)
+        return cfg
+
+    def test_apply_matches_model_correct(self):
+        cfg = self._cfg()
+        model = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        self.assertEqual(apply_eq_pointing_model(cfg, 30.0, 25.0), model.correct(30.0, 25.0))
+
+    def test_disabled_is_noop(self):
+        cfg = self._cfg(); cfg.eq_pointing_model_enabled = False
+        self.assertEqual(apply_eq_pointing_model(cfg, 30.0, 25.0), (30.0, 25.0))
+
+    def test_error_zero_at_corrected_command(self):
+        # If the mount sits exactly where the model says to command for a target, the
+        # computed mount-position error is ~0 (the correction is self-consistent).
+        from transformations import azel_to_eq_mount
+        cfg = self._cfg()
+        target_az, target_el = 210.0, 40.0
+        h_des, d_des = azel_to_eq_mount(target_az, target_el, 0.0, LAT)
+        model = EquatorialPointingModel(TRUTH, lat_deg=LAT)
+        h_cmd, d_cmd = model.correct(h_des, d_des)
+        az_err, alt_err = compute_mount_position_error(cfg, h_cmd, d_cmd, target_az, target_el)
+        self.assertLess(abs(az_err), 0.02)
+        self.assertLess(abs(alt_err), 0.02)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test_eq_transform.py
+++ b/test_eq_transform.py
@@ -1,0 +1,74 @@
+"""
+Equatorial mount transform (transformations.eq_mount_to_azel / azel_to_eq_mount): a pure
+rotation about the polar axis. Validates round-trip, agreement with the textbook
+hour-angle/declination -> alt/az formula when the pole is correctly set, the HA sign
+convention (increasing HA moves a target westward), and that the control-loop Eq branch
+no longer crashes (it was a stub that raised NameError).
+"""
+
+import math
+import unittest
+
+from transformations import eq_mount_to_azel, azel_to_eq_mount
+from config import ConfigState
+from control import compute_mount_position_error
+
+
+def _standard_hadec_to_altaz(ha_deg, dec_deg, lat_deg):
+    """Textbook HA/Dec -> Alt/Az (az from north through east), pole in the meridian."""
+    H = math.radians(ha_deg); d = math.radians(dec_deg); phi = math.radians(lat_deg)
+    sin_alt = math.sin(phi) * math.sin(d) + math.cos(phi) * math.cos(d) * math.cos(H)
+    alt = math.asin(max(-1.0, min(1.0, sin_alt)))
+    # azimuth measured from North, increasing toward East
+    y = -math.cos(d) * math.sin(H)
+    x = math.sin(d) * math.cos(phi) - math.cos(d) * math.cos(H) * math.sin(phi)
+    az = math.degrees(math.atan2(y, x)) % 360.0
+    return az, math.degrees(alt)
+
+
+class TestEqTransform(unittest.TestCase):
+    def test_round_trip(self):
+        for az_p, alt_p in [(0.0, 40.0), (0.0, 52.0), (2.0, 38.0)]:
+            for az, el in [(120, 30), (200, 60), (300, 15), (45, 75), (180, 50)]:
+                ha, dec = azel_to_eq_mount(az, el, az_p, alt_p)
+                raz, rel = eq_mount_to_azel(ha, dec, az_p, alt_p)
+                self.assertAlmostEqual(raz % 360.0, az % 360.0, places=4)
+                self.assertAlmostEqual(rel, el, places=4)
+
+    def test_matches_textbook_when_pole_in_meridian(self):
+        lat = 40.0
+        for ha in (-60, -15, 0, 30, 90):
+            for dec in (-20, 0, 35, 70):
+                az, el = eq_mount_to_azel(ha, dec, 0.0, lat)
+                eaz, eel = _standard_hadec_to_altaz(ha, dec, lat)
+                self.assertAlmostEqual(el, eel, places=3, msg=f"el ha={ha} dec={dec}")
+                # az can wrap; compare on the circle
+                self.assertAlmostEqual(((az - eaz + 180) % 360) - 180, 0.0, places=3,
+                                       msg=f"az ha={ha} dec={dec}")
+
+    def test_pole_maps_to_zenith_distance_latitude(self):
+        # The celestial pole (dec=90) sits due north at altitude=latitude.
+        az, el = eq_mount_to_azel(123.0, 90.0, 0.0, 47.0)
+        self.assertAlmostEqual(el, 47.0, places=4)
+        self.assertAlmostEqual(((az - 0 + 180) % 360) - 180, 0.0, places=3)
+
+    def test_increasing_ha_moves_west(self):
+        # On the equator at the meridian (az=180 south), +HA should head toward west (az->270).
+        az0, _ = eq_mount_to_azel(0.0, 0.0, 0.0, 40.0)
+        az1, _ = eq_mount_to_azel(20.0, 0.0, 0.0, 40.0)
+        self.assertAlmostEqual(az0, 180.0, places=3)
+        self.assertGreater(az1, 180.0)  # moved toward the western horizon
+
+    def test_control_eq_branch_does_not_crash(self):
+        cfg = ConfigState()
+        cfg.mount_mode = 'Eq'
+        cfg.lat_str = '40.0'
+        cfg.alignment_azimuth_str = '0.0'
+        cfg.alignment_elevation_str = '0.0'  # -> falls back to latitude
+        # Regression: this path used to raise NameError (the Eq branch was a stub).
+        az_err, alt_err = compute_mount_position_error(cfg, 10.0, 45.0, 200.0, 35.0)
+        self.assertTrue(math.isfinite(az_err) and math.isfinite(alt_err))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test_pointing_model.py
+++ b/test_pointing_model.py
@@ -66,6 +66,63 @@ class TestPointingModelFit(unittest.TestCase):
             self.assertLess(abs(((az_obs - az_d + 180) % 360 - 180)) * math.cos(math.radians(el_d)), 0.01)
             self.assertLess(abs(el_obs - el_d), 0.01)
 
+    def test_partial_fit_refits_index_only(self):
+        """A seeded partial fit recovers drifted IA/IE while holding the (correctly seeded)
+        mechanical terms fixed -- the nightly-refresh path."""
+        mech = {"AN": 0.07, "AW": -0.04, "NPAE": 0.05, "CA": 0.03, "TF": 0.04}
+        truth = PointingModel({"IA": 2.3, "IE": -0.9, **mech})
+        grid = fibonacci_sky_grid(8, el_min=20, el_max=78)
+        samples = self._make_samples(truth, grid, noise_arcsec=8.0, seed=3)
+        seed = dict(mech)  # last night's mechanical terms, zero index errors
+        seed.update({"IA": 0.0, "IE": 0.0})
+        model, stats = PointingModel.fit(samples, seed_terms=seed, free_terms=["IA", "IE"])
+        # Mechanical terms must be held exactly at the seed (not re-fit).
+        for k in mech:
+            self.assertEqual(model.terms[k], mech[k])
+        # Index errors recovered from only 8 points.
+        self.assertAlmostEqual(model.terms["IA"], truth.terms["IA"], delta=0.03)
+        self.assertAlmostEqual(model.terms["IE"], truth.terms["IE"], delta=0.03)
+        self.assertLess(stats["rms_after_arcmin"], 1.0)
+
+    def test_stats_report_condition_number(self):
+        """A well-spread grid is well-conditioned; a clustered one is not."""
+        truth = PointingModel({"IA": 1.0, "IE": -0.5, "AN": 0.05, "AW": 0.03,
+                               "NPAE": 0.04, "CA": 0.02, "TF": 0.03})
+        wide = self._make_samples(truth, fibonacci_sky_grid(40, el_min=15, el_max=80))
+        _, st_wide = PointingModel.fit(wide)
+        self.assertIn("design_cond", st_wide)
+        # A grid clustered in a tiny az/el patch can't separate the terms -> huge cond.
+        clustered = self._make_samples(truth, [(100 + 0.5 * i, 45 + 0.3 * i) for i in range(12)])
+        _, st_cl = PointingModel.fit(clustered)
+        self.assertGreater(st_cl["design_cond"], st_wide["design_cond"])
+
+    def test_robust_fit_rejects_outlier(self):
+        """A single grossly-wrong solve is rejected so it can't drag the model."""
+        truth = PointingModel({"IA": 1.5, "IE": -0.6, "AN": 0.06, "AW": -0.04,
+                               "NPAE": 0.05, "CA": 0.03, "TF": 0.04})
+        grid = fibonacci_sky_grid(30, el_min=15, el_max=80)
+        samples = self._make_samples(truth, grid, noise_arcsec=8.0, seed=5)
+        # Corrupt one sample with a 2-degree plate-solve blunder.
+        bad = list(samples[7]); bad[2] = (bad[2] + 2.0) % 360.0; bad[3] += 2.0
+        samples[7] = tuple(bad)
+
+        naive, st_naive = PointingModel.fit(samples, robust=False)
+        robust, st_robust = PointingModel.fit(samples, robust=True)
+        self.assertEqual(st_robust["n_rejected"], 1)
+        self.assertLess(st_robust["rms_after_arcmin"], st_naive["rms_after_arcmin"])
+        # Robust terms stay close to truth; the naive fit is pulled off by the blunder.
+        for k in TERM_NAMES:
+            self.assertAlmostEqual(robust.terms[k], truth.terms[k], delta=0.05)
+
+    def test_robust_keeps_clean_samples(self):
+        """With clean data, robust mode rejects nothing (the absolute floor protects inliers)."""
+        truth = PointingModel({"IA": 1.0, "IE": 0.5, "AN": 0.05, "AW": 0.02,
+                               "NPAE": 0.03, "CA": 0.02, "TF": 0.03})
+        grid = fibonacci_sky_grid(24, el_min=20, el_max=78)
+        samples = self._make_samples(truth, grid, noise_arcsec=8.0, seed=6)
+        _, st = PointingModel.fit(samples, robust=True)
+        self.assertEqual(st["n_rejected"], 0)
+
     def test_grid_respects_elevation_band(self):
         grid = fibonacci_sky_grid(30, el_min=20, el_max=78)
         self.assertGreater(len(grid), 10)

--- a/test_polar_align.py
+++ b/test_polar_align.py
@@ -1,0 +1,109 @@
+"""
+Plate-solve polar alignment (polar_align.py): the axis-fit math, the error/correction
+decomposition, and an end-to-end run against a deterministic sampler that rotates the RA
+axis about an injected (mis-set) polar axis -- the routine must recover that axis and report
+the right azimuth/altitude correction.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+from config import ConfigState
+from transformations import eq_mount_to_azel
+from polar_align import (PolarAlignState, PolarAlignRunner, fit_polar_axis,
+                         polar_error, DONE, ERROR)
+
+
+class _SimPolarSampler:
+    """Boresight = eq_mount_to_azel(AZM, ALT) about the injected TRUE pole; optional noise."""
+
+    def __init__(self, true_pole_az, true_pole_alt, noise_deg=0.0, seed=0, fail_all=False):
+        self.az = true_pole_az
+        self.alt = true_pole_alt
+        self.noise = noise_deg
+        self.fail_all = fail_all
+        self._azm = 0.0
+        self._alt = 0.0
+        self._rng = np.random.default_rng(seed)
+
+    def slew(self, azm, alt):
+        self._azm, self._alt = azm, alt
+        return True
+
+    def capture(self):
+        if self.fail_all:
+            return None
+        az, el = eq_mount_to_azel(self._azm, self._alt, self.az, self.alt)
+        if self.noise:
+            az += self._rng.normal(0, self.noise) / max(0.2, math.cos(math.radians(el)))
+            el += self._rng.normal(0, self.noise)
+        return (az % 360.0, el, {'n_matches': 10})
+
+
+LAT = 40.0
+
+
+class TestPolarMath(unittest.TestCase):
+    def test_fit_axis_recovers_known_pole(self):
+        # Boresights 20 deg from a pole at (3, 42), swept in HA.
+        pole = (3.0, 42.0)
+        samples = [eq_mount_to_azel(ha, 20.0, *pole) for ha in (-40, -20, 0, 20, 40)]
+        az, el = fit_polar_axis(samples, toward_az_deg=0.0, toward_alt_deg=LAT)
+        self.assertAlmostEqual(az, 3.0, places=2)
+        self.assertAlmostEqual(el, 42.0, places=2)
+
+    def test_error_directions(self):
+        # Pole too far east and too high.
+        r = polar_error(measured_az=2.0, measured_alt=42.0, target_az=0.0, target_alt=40.0)
+        self.assertAlmostEqual(r['az_error'], 2.0, places=6)
+        self.assertAlmostEqual(r['alt_error'], 2.0, places=6)
+        self.assertEqual(r['az_dir'], 'west')   # correction: move west
+        self.assertEqual(r['alt_dir'], 'down')  # correction: lower
+        self.assertGreater(r['total_deg'], 0.0)
+
+    def test_perfect_alignment_is_zero(self):
+        r = polar_error(0.0, LAT, 0.0, LAT)
+        self.assertLess(r['total_deg'], 1e-4)  # acos near 1.0 leaves ~sub-arcsec float noise
+
+
+class TestPolarRun(unittest.TestCase):
+    def _run(self, true_az, true_alt, **kw):
+        cfg = ConfigState()
+        cfg.mount_mode = 'Eq'
+        cfg.lat_str = str(LAT)
+        state = PolarAlignState()
+        sampler = _SimPolarSampler(true_az, true_alt, **kw)
+        runner = PolarAlignRunner(state, cfg, sampler, target_az=0.0, target_alt=LAT,
+                                  n_points=6, dec_deg=20.0, ha_span_deg=90.0)
+        runner.run()
+        return state
+
+    def test_recovers_injected_misalignment(self):
+        state = self._run(2.5, 41.5)
+        self.assertEqual(state.phase, DONE, state.error)
+        az_m, alt_m = state.measured_pole
+        self.assertAlmostEqual(az_m, 2.5, places=2)
+        self.assertAlmostEqual(alt_m, 41.5, places=2)
+        self.assertAlmostEqual(state.result['az_error'], 2.5, delta=0.02)
+        self.assertAlmostEqual(state.result['alt_error'], 1.5, delta=0.02)
+
+    def test_recovers_under_noise(self):
+        state = self._run(-1.5, 38.5, noise_deg=10.0 / 3600.0, seed=3)
+        self.assertEqual(state.phase, DONE, state.error)
+        self.assertAlmostEqual(state.result['az_error'], -1.5, delta=0.1)
+        self.assertAlmostEqual(state.result['alt_error'], -1.5, delta=0.1)
+
+    def test_total_solve_failure_errors(self):
+        cfg = ConfigState(); cfg.lat_str = str(LAT)
+        state = PolarAlignState()
+        runner = PolarAlignRunner(state, cfg, _SimPolarSampler(0, LAT, fail_all=True),
+                                  target_az=0.0, target_alt=LAT, n_points=5)
+        runner.run()
+        self.assertEqual(state.phase, ERROR)
+        self.assertIsNone(state.measured_pole)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test_simulator.py
+++ b/test_simulator.py
@@ -23,7 +23,7 @@ from config import ConfigState
 from lib.auxstar import RATES, Targets
 from hotspot import detect_hotspot, pixel_offset_to_angles
 import simulator
-from simulator import SimMount, HardwareSimulator, angles_to_pixel
+from simulator import SimMount, HardwareSimulator, angles_to_pixel, injected_boresight
 
 
 class MountDynamicsTests(unittest.TestCase):
@@ -114,6 +114,59 @@ class RenderDetectTests(unittest.TestCase):
         sim.mount._az_rate_dps = 5.0  # moving -> stars streak -> more lit pixels
         streaked = sim.render_frame(0).astype(np.int32).sum()
         self.assertGreater(streaked, static)
+
+
+class InjectedErrorTests(unittest.TestCase):
+    """The sim can inject a full pointing model + refraction so an alignment run recovers
+    all seven terms end-to-end (not just the encoder-bias IA/IE)."""
+
+    def test_no_injection_is_identity(self):
+        cfg = ConfigState()
+        az, el = injected_boresight(cfg, 123.0, 45.0)
+        self.assertAlmostEqual(az, 123.0, places=9)
+        self.assertAlmostEqual(el, 45.0, places=9)
+
+    def test_pointing_model_matches_predict_observed(self):
+        from pointing_model import PointingModel
+        terms = {"IA": 0.4, "IE": -0.2, "AN": 0.05, "AW": -0.03, "NPAE": 0.04, "CA": 0.02, "TF": 0.03}
+        cfg = ConfigState()
+        cfg.sim_config["mount_pointing_model"] = terms
+        exp_az, exp_el = PointingModel(terms).predict_observed(80.0, 50.0)
+        az, el = injected_boresight(cfg, 80.0, 50.0)
+        self.assertAlmostEqual(az, exp_az, places=9)
+        self.assertAlmostEqual(el, exp_el, places=9)
+
+    def test_refraction_lifts_elevation(self):
+        from pointing_model import bennett_refraction_deg
+        cfg = ConfigState()
+        cfg.sim_config["sim_refraction"] = True
+        az, el = injected_boresight(cfg, 200.0, 25.0)
+        self.assertAlmostEqual(az, 200.0, places=9)
+        self.assertAlmostEqual(el, 25.0 + bennett_refraction_deg(25.0), places=9)
+        self.assertGreater(el, 25.0)  # apparent is higher than geometric
+
+    def test_render_shifts_field_by_injected_model(self):
+        """A large injected IA shifts the rendered boresight, so a target placed at the
+        nominal boresight no longer lands at frame center."""
+        cfg = ConfigState()
+        cfg.sim_config["enabled"] = True
+        cfg.sim_config["mount_encoder_noise_deg"] = 0.0
+        cfg.sim_config["read_noise"] = 0.0
+        sim = HardwareSimulator(cfg, None, None)
+        sim.mount.az_true_deg, sim.mount.el_true_deg = 100.0, 60.0  # nominal sky boresight az100 el30
+        # Target sits exactly at the NOMINAL boresight (az 100, el 30).
+        sim.current_target_azel = lambda: (100.0, 30.0, 'satellite', True)
+
+        cfg.sim_config["mount_pointing_model"] = {}
+        d0 = detect_hotspot(sim.render_frame(0), snr_threshold=5.0)
+        self.assertIsNotNone(d0)
+        h, w = cfg.sim_config["cam_height"], cfg.sim_config["cam_width"]
+        self.assertLess(abs(d0.cx - w / 2) + abs(d0.cy - h / 2), 3.0)  # centered, no model
+
+        cfg.sim_config["mount_pointing_model"] = {"IA": 0.3}  # ~0.3 deg azimuth shift
+        d1 = detect_hotspot(sim.render_frame(0), snr_threshold=5.0)
+        self.assertIsNotNone(d1)
+        self.assertGreater(abs(d1.cx - w / 2) + abs(d1.cy - h / 2), 5.0)  # shifted off-center
 
 
 class SimInTheLoopTests(unittest.TestCase):

--- a/transformations.py
+++ b/transformations.py
@@ -273,6 +273,49 @@ def AzEl2AzAlt_Passthrough(az, el):
     # Passthrough: sky coordinates are mount coordinates
     return az, el
 
+def _eq_basis(pole_az_deg, pole_alt_deg):
+    """Orthonormal equatorial basis (z=pole, x=upper-meridian equator, y=west) in the local
+    horizontal frame, for a polar axis pointing at (pole_az, pole_alt).
+
+    For a correctly polar-aligned mount in the northern hemisphere pole_az=0 (north) and
+    pole_alt=latitude. Letting the pole be an arbitrary direction is what makes this model
+    able to represent (and the polar-alignment routine able to measure) a mis-set polar axis.
+    """
+    p = cartesian_from_az_el(pole_az_deg, pole_alt_deg)        # celestial pole (z_eq)
+    up = np.array([0.0, 0.0, 1.0])
+    x = up - np.dot(up, p) * p                                 # H=0, dec=0 (upper meridian)
+    nx = np.linalg.norm(x)
+    if nx < 1e-9:                                              # pole at zenith: pick a meridian
+        x = np.array([1.0, 0.0, 0.0]) - p[0] * p
+        x /= np.linalg.norm(x)
+    else:
+        x /= nx
+    y = np.cross(p, x)                                         # west on the equator
+    return p, x, y
+
+
+def eq_mount_to_azel(ha_deg, dec_deg, pole_az_deg, pole_alt_deg):
+    """Equatorial mount axes (hour angle, declination) -> true horizontal (az, el).
+
+    AZM motor = hour angle (increases westward), ALT motor = declination. The mapping is a
+    pure rotation about the polar axis, so a sidereal target is tracked by turning HA alone.
+    """
+    p, x, y = _eq_basis(pole_az_deg, pole_alt_deg)
+    H = math.radians(ha_deg)
+    d = math.radians(dec_deg)
+    v = (math.cos(d) * math.cos(H)) * x + (math.cos(d) * math.sin(H)) * y + math.sin(d) * p
+    return az_el_from_cartesian(v)
+
+
+def azel_to_eq_mount(az_deg, el_deg, pole_az_deg, pole_alt_deg):
+    """Inverse of :func:`eq_mount_to_azel`: true horizontal (az, el) -> (hour angle, dec)."""
+    p, x, y = _eq_basis(pole_az_deg, pole_alt_deg)
+    v = cartesian_from_az_el(az_deg, el_deg)
+    dec = math.degrees(math.asin(float(np.clip(np.dot(v, p), -1.0, 1.0))))
+    ha = math.degrees(math.atan2(float(np.dot(v, y)), float(np.dot(v, x))))
+    return ha, dec
+
+
 def compute_fov_for_camera(pixel_size_um, focal_length_mm, roi_width_pct, roi_height_pct,
                           camera_width_pixels, camera_height_pixels):
     """


### PR DESCRIPTION
Alignment improvements across three areas, all sim-tested headlessly.

Field-speed (mount-mode independent):
- Capture-on-the-move: loosen slew settle (config alignment_settle_tol_deg/ _cycles) since capture() pairs the encoder-at-solve-time with the plate solve, so tight settling was wasted dusk time.
- Quick Refit: PointingModel partial fit (seed_terms/free_terms) re-fits only the drifting index errors (IA/IE) holding stable mechanical terms; UI button.
- Opt-in adaptive early-stop (alignment_target_rms_arcmin, default off).

Test robustness:
- Sim injects a full pointing model + refraction (injected_boresight) so a sim run recovers all 7 terms end-to-end, not just encoder-bias IA/IE.
- PointingModel.fit: robust MAD outlier rejection (absolute floor protects clean fits; on by default in the runner) + condition-number / n_rejected reporting.
- Deterministic SimMount end-to-end, refraction, and solve-failure tests.

Equatorial mount support:
- Clean rotation-based EQ transform (eq_mount_to_azel / azel_to_eq_mount) about an arbitrary polar axis; validated against textbook HA/Dec->Alt/Az. Rewrites the broken control.py Eq branch (was a NameError stub) and fixes the mount_mode default; sim renders Eq via the same transform with an injectable true pole (sim_pole_*_err_deg).
- Plate-solve polar alignment (polar_align.py): rotate the RA axis, fit the axis direction from the boresight samples, report az/alt knob corrections.
- Equatorial 7-term pointing model (eq_pointing_model.py): IH/ID/NP/CH/ME/MA and a latitude-aware tube-flexure term; applied in HA/Dec (control.apply_eq_ pointing_model). AlignmentRunner is now mode-aware and fits it via EqGuiSampler.

New tests: test_eq_transform, test_polar_align, test_eq_pointing_model (+ EQ and
robustness cases in the existing suites). Full sweep: 88 tests green.