### PR TITLE
Lucky-imaging post-processing: PIPP-style prep + AutoStakkert-style stacking

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -6,6 +6,36 @@ Newest entries first.
 
 ---
 
+## 2026-06-30 — Lucky-imaging stacking (PIPP/AutoStakkert) gotchas
+
+Adding the stacking pipeline ([`stacking.py`](stacking.py)) surfaced three
+non-obvious traps, all caught by an adversarial review pass before merge:
+
+- **Alignment-point grid must span edge-to-edge.** AutoStakkert-style local
+  warping measures a per-point shift on a coarse grid, then upsamples it to a
+  dense field with `cv2.resize`. `resize` maps grid node 0 → pixel 0 and the
+  last node → pixel `size-1`, so if the grid is *inset* by a margin, every
+  measured shift is re-applied ~margin px away from where it was measured — it
+  actively warps detail to the wrong place near the borders. Fix: place nodes on
+  `linspace(0, size-1, n)` and let `measure_local_shifts` clamp each patch
+  inward at the edges instead of insetting the nodes.
+- **Stacking must be per-pixel coverage weighted, not sum/count.** Aligning a
+  jittered frame shifts real pixels in and leaves `BORDER_CONSTANT` black at the
+  revealed edge. A naive `sum / frame_count` average then darkens a whole border
+  band proportional to the jitter. Accumulate a per-pixel coverage mask (warp an
+  all-ones image by the same transform) alongside the sum and divide by it; the
+  reference covers the whole frame so every pixel keeps a valid average.
+- **Derive reconciling stats.** Tracking `n_total` as its own counter drifted
+  out of sync with `n_stacked`/`n_rejected` (the directly-set reference frame
+  was never counted), yielding "stacked 10 of 9". Derive
+  `n_total = n_stacked + n_rejected` so the counts can't disagree.
+
+General principle reaffirmed: any "coarse grid → dense field via resize" step has
+an off-by-the-margin registration trap, and any align-then-average step needs a
+coverage denominator, not a frame count.
+
+---
+
 ## 2026-06-24 — Recovering joystick-mode render & sim-imaging FPS
 
 **Symptom.** After the navball rebuild and the ADS-B additions, the Joystick Loop

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -6,6 +6,44 @@ Newest entries first.
 
 ---
 
+## 2026-07-03 — Stacking performance + the "sharpness rewards noise" trap
+
+Profiling the stacking pipeline ([`stacking.py`](stacking.py)) on realistic
+1920×1080 frames overturned two assumptions and surfaced a correctness trap that
+matters more than the speed.
+
+**Where the time actually goes.** Decode of the uncompressed BMPs is ~1.6 ms/frame
+(and OpenCV's `IMREAD_REDUCED_*` does *not* help BMP — it's already memory-bound),
+so the earlier "double-decode" worry was a non-issue. The real costs are the
+**sharpness metric** (`cv2.Laplacian` at `CV_64F` ≈ 11 ms/frame) and **ORB
+feature detection** (≈ 25 ms/frame, the dominant stack cost). Fixes: `CV_64F →
+CV_32F` (~2×, variance identical for ranking); optional reduced-res grading
+(5–10×, ranking-preserving); a `ThreadPoolExecutor` over frames (OpenCV releases
+the GIL, so ~1.7× on the align-bound pass across 4 cores even though cv2 already
+threads internally); and an opt-in half-res *alignment* (`align_scale`, ~2× on
+detect for **extended/textured** targets — point-source star fields blur away
+when downscaled, so it's target-dependent and defaults off).
+
+**The trap: Laplacian variance rewards noise.** A pure sensor-noise / hot-pixel
+frame scores a *huge* sharpness (measured ~10 000) while a faint but real target
+scores ~0. So a naive "keep the top X% by sharpness" first pass does the opposite
+of its job — it **keeps the junk and discards the good frames**, and then the
+stacker can't align the noise so it stacks almost nothing (measured 1/60). The
+fix is a two-tier cull: a cheap, noise-robust `content_score` (reduce with
+area-averaging → Gaussian blur → `max − median` prominence) gates out frames with
+*no signal* first, *then* the precise sharpness metric ranks the survivors.
+Structure survives denoising; noise collapses — so faint real frames are kept and
+noise/blank frames are dropped before ranking ever sees them.
+
+**Parallel stacking without locks.** The align+average pass is parallelized as a
+map-reduce: K worker stackers share one read-only alignment reference (only one
+*seeds* it into its accumulator, so the merged master counts it once), each
+accumulates its own slice, and the partial float sums are added at the end — no
+lock on the hot path. Trim `cv2.setNumThreads` while the Python pool runs so the
+two thread pools don't oversubscribe the cores.
+
+---
+
 ## 2026-06-30 — Lucky-imaging stacking (PIPP/AutoStakkert) gotchas
 
 Adding the stacking pipeline ([`stacking.py`](stacking.py)) surfaced three

--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ than alt-tabbing between many GUI programs.
   acquisition, tracked-object handoff, click-in-image selection, and labeled
   capture (UTC, mount az/el, rate, centroid per frame).
 - **Post-processing** — quick-look and product generation to get a good shot
-  posted fast.
+  posted fast. A PIPP-style prep stage (sharpness grading, "lucky" frame
+  culling, target centring/cropping) feeds an AutoStakkert-style stacker that
+  aligns and averages the best frames — optionally with alignment-point local
+  warping — into one high-SNR master ready for wavelet sharpening.
 
 We deliberately don't try to re-create everything existing tools (Heavens-Above,
 SkyTrack, KStars, etc.) already do well — the focus is the niche capabilities

--- a/post_process.py
+++ b/post_process.py
@@ -998,7 +998,8 @@ class StackExporter:
 
     def __init__(self, run, cam_index, t_start, t_end, out_path,
                  keep_fraction=0.5, quality="laplacian", method="orb",
-                 local=False, roi=None, max_frames=None):
+                 local=False, roi=None, max_frames=None, workers=None,
+                 grade_scale=1.0, prefilter=True):
         self.run = run
         self.cam_index = cam_index
         self.t_start = t_start
@@ -1010,6 +1011,9 @@ class StackExporter:
         self.local = local
         self.roi = roi
         self.max_frames = max_frames
+        self.workers = workers          # None -> all cores
+        self.grade_scale = grade_scale  # <1 grades at reduced res for speed
+        self.prefilter = prefilter      # conservative garbage pre-cull
 
         self.progress = 0.0
         self.done = False
@@ -1044,7 +1048,9 @@ class StackExporter:
             self.run, self.cam_index, keep_fraction=self.keep_fraction,
             quality=self.quality, method=self.method, local=self.local,
             roi=self.roi, t_start=self.t_start, t_end=self.t_end,
-            max_frames=self.max_frames, progress=_progress)
+            max_frames=self.max_frames, workers=self.workers,
+            grade_scale=self.grade_scale, prefilter=self.prefilter,
+            progress=_progress)
         if result.master is None:
             raise RuntimeError("No alignable frames in the selected range to stack")
         self.out_path = save_master(result.master, self.out_path)

--- a/post_process.py
+++ b/post_process.py
@@ -976,3 +976,78 @@ class Mp4Exporter:
                 self.progress = (i + 1) / total
         finally:
             writer.release()
+
+
+# ---------------------------------------------------------------------------
+# Lucky-imaging stack export (PIPP cull/centre + AutoStakkert align/average)
+# ---------------------------------------------------------------------------
+class StackExporter:
+    """Export a high-SNR stacked master from a camera's frame range.
+
+    This is the AutoStakkert end of the pipeline wired to the replay UI: grade
+    the frames in ``[t_start, t_end]`` by sharpness, keep the sharpest
+    ``keep_fraction``, align them to the sharpest frame and average them into one
+    low-noise image (optionally with alignment-point local warping). Image
+    adjustments are intentionally *not* baked in -- a stacked master is the
+    linear input to a later wavelet/deconvolution sharpening step.
+
+    Mirrors :class:`Mp4Exporter`'s threading contract: call :meth:`start`, then
+    poll :attr:`progress` / :attr:`done` / :attr:`error` and read
+    :attr:`out_path` / :attr:`stats` when finished.
+    """
+
+    def __init__(self, run, cam_index, t_start, t_end, out_path,
+                 keep_fraction=0.5, quality="laplacian", method="orb",
+                 local=False, roi=None, max_frames=None):
+        self.run = run
+        self.cam_index = cam_index
+        self.t_start = t_start
+        self.t_end = t_end
+        self.out_path = out_path
+        self.keep_fraction = keep_fraction
+        self.quality = quality
+        self.method = method
+        self.local = local
+        self.roi = roi
+        self.max_frames = max_frames
+
+        self.progress = 0.0
+        self.done = False
+        self.error = None
+        self.stats = None
+        self.frames_written = 0
+        self._thread = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def is_alive(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def _worker(self):
+        try:
+            self._export()
+        except Exception as exc:
+            self.error = str(exc)
+        finally:
+            self.done = True
+
+    def _export(self):
+        # Imported lazily so post_process stays importable without the stacker.
+        from stacking import stack_run, save_master
+
+        def _progress(done, total):
+            self.progress = done / total if total else 1.0
+
+        result = stack_run(
+            self.run, self.cam_index, keep_fraction=self.keep_fraction,
+            quality=self.quality, method=self.method, local=self.local,
+            roi=self.roi, t_start=self.t_start, t_end=self.t_end,
+            max_frames=self.max_frames, progress=_progress)
+        if result.master is None:
+            raise RuntimeError("No alignable frames in the selected range to stack")
+        self.out_path = save_master(result.master, self.out_path)
+        self.stats = result.stats
+        self.frames_written = result.stats.n_stacked
+        self.progress = 1.0

--- a/post_process_ui.py
+++ b/post_process_ui.py
@@ -24,7 +24,8 @@ import pygame
 
 from utils import draw_button
 from post_process import (
-    RunLibrary, ReplayEngine, Mp4Exporter, fmt_utc, compute_track_vectors,
+    RunLibrary, ReplayEngine, Mp4Exporter, StackExporter, fmt_utc,
+    compute_track_vectors,
 )
 
 # Colors
@@ -513,6 +514,18 @@ def _draw_controls(display, state, x, y, w):
         _button(display, r, label)
         state.rects[key] = r
         cy += 34
+
+    # Stack (lucky imaging: cull sharpest frames -> align -> average to a master)
+    pygame.draw.line(screen, (80, 80, 90), (cx, cy), (x + w - 12, cy)); cy += 8
+    _text(display, "Stack best frames (In->Out):", cx, cy, display.small_font, _MUTED)
+    cy += 22
+    for key, label in (("stack_25", "Stack best 25%"),
+                       ("stack_50", "Stack best 50%"),
+                       ("stack_50_local", "Stack 50% (align points)")):
+        r = pygame.Rect(cx, cy, w - 24, 28)
+        _button(display, r, label)
+        state.rects[key] = r
+        cy += 34
     if state.exporter is not None:
         msg = (f"Exporting... {state.exporter.progress * 100:.0f}%"
                if not state.exporter.done else state.export_msg)
@@ -684,6 +697,14 @@ def _click_replay(pos, display, state, status_messages):
         _start_export(state, status_messages, eng.t0, eng.t1,
                       stabilize=eng.stabilize_on, tag="full"); return
 
+    # Stack (In->Out range)
+    if _hit(R, "stack_25", pos):
+        _start_stack_export(state, status_messages, 0.25, local=False, tag="stack25"); return
+    if _hit(R, "stack_50", pos):
+        _start_stack_export(state, status_messages, 0.50, local=False, tag="stack50"); return
+    if _hit(R, "stack_50_local", pos):
+        _start_stack_export(state, status_messages, 0.50, local=True, tag="stack50ap"); return
+
 
 def _hit(R, key, pos):
     r = R.get(key)
@@ -731,6 +752,25 @@ def _start_export(state, status_messages, t_start, t_end, stabilize, tag):
     state.exporter.start()
     state.export_msg = ""
     status_messages.append(f"Post: exporting {os.path.basename(out)}")
+
+
+def _start_stack_export(state, status_messages, keep_fraction, local, tag):
+    if state.exporter is not None:
+        status_messages.append("Post: export already running"); return
+    os.makedirs(_EXPORT_DIR, exist_ok=True)
+    eng = state.engine
+    cam = state.active_cam
+    safe = state.run.folder.replace(os.sep, "_")
+    out = os.path.join(_EXPORT_DIR, f"{safe}_cam{cam + 1}_{tag}.png")
+    # Stack the marked In->Out range; the master is intentionally linear (no
+    # gamma/brightness/contrast baked in) so it feeds a later sharpening step.
+    state.exporter = StackExporter(
+        state.run, cam, eng.in_marker, eng.out_marker, out,
+        keep_fraction=keep_fraction, local=local, method=eng.stab_method)
+    state.exporter.start()
+    state.export_msg = ""
+    status_messages.append(f"Post: stacking best {int(keep_fraction * 100)}% "
+                           f"-> {os.path.basename(out)}")
 
 
 def handle_pp_motion(pos, display, state, buttons):

--- a/stacking.py
+++ b/stacking.py
@@ -166,10 +166,8 @@ class QualityGrader:
         """Grade an iterable of frames, returning ``FrameGrade`` in input order."""
         grades = []
         for i, f in enumerate(frames):
-            arr = _as_array(f)
-            s = 0.0 if arr is None else sharpness(arr, self.method, self.roi)
             src = f if not isinstance(f, np.ndarray) else None
-            grades.append(FrameGrade(i, s, src))
+            grades.append(FrameGrade(i, self.score(f), src))
         return grades
 
 
@@ -197,11 +195,17 @@ def select_best(grades, fraction=None, count=None, min_keep=1):
 # ---------------------------------------------------------------------------
 # PIPP stage: target finding, centering, cropping
 # ---------------------------------------------------------------------------
+def _default_threshold(gray):
+    """The shared 'sky' cut: pixels above ``mean + 2*std`` count as target."""
+    g = gray.astype(np.float64)
+    return float(g.mean() + 2.0 * g.std())
+
+
 def _foreground(gray, threshold):
     """Background-subtracted foreground weights (>=0) and the threshold used."""
     g = gray.astype(np.float64)
     if threshold is None:
-        threshold = float(g.mean() + 2.0 * g.std())
+        threshold = _default_threshold(g)
     return np.clip(g - threshold, 0.0, None), threshold
 
 
@@ -238,7 +242,7 @@ def bounding_box(frame, threshold=None, pad=0):
     _require_cv2()
     gray = _to_gray(frame).astype(np.float64)
     if threshold is None:
-        threshold = float(gray.mean() + 2.0 * gray.std())
+        threshold = _default_threshold(gray)
     mask = gray > threshold
     if not mask.any():
         return None
@@ -270,9 +274,10 @@ def crop_centered(frame, center, size, pad_value=0):
     shape = (out_h, out_w) + arr.shape[2:]
     canvas = np.full(shape, pad_value, dtype=arr.dtype)
 
-    # Source top-left so that ``center`` lands at the output centre.
-    sx0 = int(round(cx - out_w / 2.0))
-    sy0 = int(round(cy - out_h / 2.0))
+    # Source top-left so that ``center`` lands on the output's centre pixel
+    # (index ``out//2`` -- correct for odd sizes, not biased by a 0.5 round).
+    sx0 = int(round(cx)) - out_w // 2
+    sy0 = int(round(cy)) - out_h // 2
     src_h, src_w = arr.shape[:2]
 
     # Overlap of the requested source window with the actual image.
@@ -332,35 +337,42 @@ class AlignmentPointGrid:
         return len(self.points)
 
     @classmethod
-    def over(cls, shape, spacing=80, margin=None):
+    def over(cls, shape, spacing=80):
         """Build a grid spanning ``shape`` (h, w) at roughly ``spacing`` px apart.
 
-        At least a 2x2 grid is produced so the displacement field can be
-        bilinearly upsampled.
+        Nodes run edge-to-edge (the first/last sit on pixel 0 and ``size-1``) so
+        that upsampling the coarse shift grid with :func:`cv2.resize` lands each
+        node's displacement back on the pixel it was measured at -- an inset grid
+        would be stretched to the borders and apply every shift ~inset px off.
+        Patches near an edge are clamped inward by :func:`measure_local_shifts`,
+        so edge nodes are safe. At least a 2x2 grid is produced so the field can
+        be bilinearly upsampled.
         """
         h, w = shape[:2]
         spacing = max(1, int(spacing))
-        if margin is None:
-            margin = spacing // 2
-        margin = int(max(0, min(margin, (min(h, w) - 1) // 2)))
-        cols = max(2, 1 + (w - 2 * margin) // spacing)
-        rows = max(2, 1 + (h - 2 * margin) // spacing)
-        xs = np.linspace(margin, w - 1 - margin, cols)
-        ys = np.linspace(margin, h - 1 - margin, rows)
+        cols = max(2, 1 + (w - 1) // spacing)
+        rows = max(2, 1 + (h - 1) // spacing)
+        xs = np.linspace(0, w - 1, cols)
+        ys = np.linspace(0, h - 1, rows)
         gx, gy = np.meshgrid(xs, ys)
         points = np.column_stack([gx.ravel(), gy.ravel()])
         return cls(points, rows, cols, shape)
 
 
-def measure_local_shifts(ref_gray, frame_gray, points, patch=48, min_response=0.0):
+def measure_local_shifts(ref_gray, frame_gray, points, patch=48, min_response=0.0,
+                         max_shift=None):
     """Per-point sub-pixel shift of ``frame`` vs ``ref`` at each alignment point.
 
     For each point a square patch (side ``patch``) is cut from both images and
     registered with phase correlation. The returned ``(N, 2)`` array holds the
     ``(dx, dy)`` that maps a reference location to where that content sits in the
     frame -- i.e. ``frame`` sampled at ``ref_xy + shift`` lands back on ``ref``.
-    Points whose correlation response is below ``min_response`` (or that fall too
-    near an edge) report a zero shift.
+    Points whose correlation response is below ``min_response`` report a zero
+    shift. ``max_shift`` (px) rejects implausibly large per-point shifts -- a
+    structureless sky patch can phase-correlate to garbage, and without this
+    guard one bad node would smear a whole band of the master via the upsampled
+    field; such points fall back to a zero shift, mirroring how
+    :class:`stabilizer.Stabilizer` rejects implausible global fits.
     """
     _require_cv2()
     ref = ref_gray if ref_gray.ndim == 2 else _to_gray(ref_gray)
@@ -387,6 +399,8 @@ def measure_local_shifts(ref_gray, frame_gray, points, patch=48, min_response=0.
         (dx, dy), response = cv2.phaseCorrelate(a, b, win)
         if response < min_response:
             continue
+        if max_shift is not None and (abs(dx) > max_shift or abs(dy) > max_shift):
+            continue  # implausible -> treat as no local correction at this node
         shifts[i] = (dx, dy)
     return shifts
 
@@ -432,12 +446,19 @@ class LuckyStacker:
     is the low-noise master. Frames that fail to align are dropped (counted in
     :attr:`stats`) rather than smeared into the result.
 
+    Averaging is **per-pixel coverage weighted**: aligning a frame shifts real
+    pixels in and leaves black (BORDER_CONSTANT) at the revealed edge, so each
+    contribution is masked and a per-pixel weight is accumulated alongside the
+    sum. Dividing sum by weight (rather than a single frame count) keeps the
+    shifted black borders from darkening the master's edges -- the reference
+    covers the whole frame, so every pixel keeps a valid average.
+
     Typical use is to feed only the sharpest top X% (see :func:`select_best`),
     with the sharpest frame as the reference.
     """
 
     def __init__(self, method="orb", local=False, ap_spacing=80, ap_patch=48,
-                 full_affine=False, min_local_response=0.0):
+                 full_affine=False, min_local_response=0.0, max_local_shift=None):
         _require_cv2()
         self.method = method
         self.local = bool(local)
@@ -445,13 +466,16 @@ class LuckyStacker:
         self.ap_patch = int(ap_patch)
         self.full_affine = bool(full_affine)
         self.min_local_response = float(min_local_response)
+        # Default cap on a single alignment point's shift: a quarter of the patch.
+        self.max_local_shift = (self.ap_patch / 4.0 if max_local_shift is None
+                                else float(max_local_shift))
 
         self._stab = None
         self._ref_gray = None
         self._grid = None
-        self._accum = None
+        self._accum = None       # float64 HxWx3 weighted sum
+        self._weight = None      # float64 HxW per-pixel coverage
         self._count = 0
-        self.n_total = 0
         self.n_rejected = 0
 
     # ------------------------------------------------------------- reference
@@ -464,6 +488,7 @@ class LuckyStacker:
         self._stab.set_reference(arr)
         self._ref_gray = _to_gray(arr).astype(np.float32)
         self._accum = arr.astype(np.float64).copy()
+        self._weight = np.ones(arr.shape[:2], dtype=np.float64)  # full coverage
         self._count = 1
         if self.local:
             self._grid = AlignmentPointGrid.over(arr.shape, self.ap_spacing)
@@ -479,24 +504,36 @@ class LuckyStacker:
         The first ``add`` with no reference set adopts the frame as reference.
         """
         arr = _as_array(frame)
-        self.n_total += 1
+        if not self.has_reference:
+            if arr is None:
+                self.n_rejected += 1
+                return False
+            self.set_reference(arr)
+            return True
         if arr is None:
             self.n_rejected += 1
             return False
-        if not self.has_reference:
-            self.set_reference(arr)
-            return True
 
-        warped, _ = self._stab.stabilize(arr)
+        warped, M = self._stab.stabilize(arr)
         if not self._stab.last_ok:
             self.n_rejected += 1
             return False
+
+        # Coverage mask: where the aligning warp brought in real (non-border) px.
+        h, w = arr.shape[:2]
+        cover = cv2.warpAffine(
+            np.ones((h, w), np.float32), M.astype(np.float32), (w, h),
+            flags=cv2.INTER_NEAREST, borderMode=cv2.BORDER_CONSTANT, borderValue=0)
         if self.local and self._grid is not None:
             shifts = measure_local_shifts(
                 self._ref_gray, _to_gray(warped), self._grid.points,
-                patch=self.ap_patch, min_response=self.min_local_response)
+                patch=self.ap_patch, min_response=self.min_local_response,
+                max_shift=self.max_local_shift)
             warped = warp_by_grid(warped, self._grid, shifts)
-        self._accum += warped.astype(np.float64)
+            cover = warp_by_grid(cover, self._grid, shifts, border=cv2.BORDER_CONSTANT)
+        cover = np.clip(cover, 0.0, 1.0)
+        self._accum += warped.astype(np.float64) * cover[..., None]
+        self._weight += cover
         self._count += 1
         return True
 
@@ -511,11 +548,14 @@ class LuckyStacker:
         """The averaged master frame (uint8 RGB), or None if nothing stacked."""
         if self._count == 0 or self._accum is None:
             return None
-        return np.clip(self._accum / self._count, 0, 255).astype(np.uint8)
+        denom = np.maximum(self._weight, 1e-6)[..., None]
+        return np.clip(self._accum / denom, 0, 255).astype(np.uint8)
 
     @property
     def stats(self):
-        return StackStats(self.n_total, self._count, self.n_rejected)
+        # n_total is derived so it always reconciles: every frame offered to the
+        # stacker is either stacked (incl. the reference) or rejected.
+        return StackStats(self._count + self.n_rejected, self._count, self.n_rejected)
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +596,8 @@ def stack_run(run, cam_index, keep_fraction=0.5, keep_count=None,
     if not grades:
         return StackResult(None, StackStats(0, 0, 0), [], [], None)
 
-    kept = select_best(grades, fraction=None if keep_count else keep_fraction,
+    kept = select_best(grades,
+                       fraction=keep_fraction if keep_count is None else None,
                        count=keep_count)
     reference_index = kept[0].index  # sharpest frame anchors the stack
 

--- a/stacking.py
+++ b/stacking.py
@@ -34,7 +34,9 @@ alignment) and the on-disk frame indexing in :class:`post_process.Run`.
 """
 
 import os
+import threading
 from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 
@@ -96,7 +98,7 @@ def _clamp_roi(shape, roi):
 SHARPNESS_METHODS = ("laplacian", "tenengrad", "fft")
 
 
-def sharpness(frame, method="laplacian", roi=None):
+def sharpness(frame, method="laplacian", roi=None, scale=1.0):
     """Estimate a frame's sharpness as a single non-negative score.
 
     Higher means sharper. The score is only meaningful *relative* to other
@@ -111,19 +113,31 @@ def sharpness(frame, method="laplacian", roi=None):
         optional (x, y, w, h) sub-box (full-frame px) to score only the target
         region -- keeps a bright, sharp target from being averaged out by a
         large empty sky.
+    scale
+        <1.0 downsamples the (gray, ROI-cropped) frame before scoring. Since the
+        score is used only to *rank* frames, a reduced-resolution pass is far
+        cheaper and preserves ordering; use 1.0 for the most discriminating pass.
+
+    Uses single-precision (``CV_32F``) accumulators -- the variance/energy is
+    identical to double precision for ranking but roughly halves the cost on a
+    full-frame image.
     """
     _require_cv2()
     gray = _to_gray(frame)
     if roi is not None:
         x, y, w, h = _clamp_roi(gray.shape, roi)
         gray = gray[y:y + h, x:x + w]
+    if scale != 1.0 and gray.size:
+        gh, gw = gray.shape
+        nw, nh = max(1, int(gw * scale)), max(1, int(gh * scale))
+        gray = cv2.resize(gray, (nw, nh), interpolation=cv2.INTER_AREA)
     if gray.size == 0:
         return 0.0
     if method == "laplacian":
-        return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+        return float(cv2.Laplacian(gray, cv2.CV_32F).var())
     if method == "tenengrad":
-        gx = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
-        gy = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
+        gx = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
+        gy = cv2.Sobel(gray, cv2.CV_32F, 0, 1, ksize=3)
         return float(np.mean(gx * gx + gy * gy))
     if method == "fft":
         return _fft_sharpness(gray)
@@ -144,31 +158,81 @@ def _fft_sharpness(gray):
     return high / total
 
 
+def content_score(frame, scale=0.25, blur=2.0):
+    """A noise-robust "is there real signal here" score (higher = more signal).
+
+    Sharpness metrics are *fooled by noise*: a pure sensor-noise or hot-pixel
+    frame has a huge Laplacian variance and would be ranked as the sharpest,
+    while a faint but real target scores near zero -- so a naive top-X% cull
+    would keep the junk and discard the good frames. This score instead measures
+    the *prominence* of the brightest structure after denoising: the frame is
+    reduced (``scale``, area-averaging beats down noise) and Gaussian-blurred
+    (``blur``), then scored as ``max - median``. A real target/starfield keeps a
+    prominent peak; uniform sky and structureless noise collapse toward zero.
+
+    It is deliberately cheap (runs at reduced resolution) and is used only as a
+    *conservative* first-pass gate to drop obviously empty/garbage frames, never
+    to rank the good ones -- that is what :func:`sharpness` is for.
+    """
+    _require_cv2()
+    gray = _to_gray(frame)
+    if gray.size == 0:
+        return 0.0
+    gh, gw = gray.shape
+    nw, nh = max(1, int(gw * scale)), max(1, int(gh * scale))
+    small = cv2.resize(gray, (nw, nh), interpolation=cv2.INTER_AREA).astype(np.float32)
+    if blur > 0:
+        small = cv2.GaussianBlur(small, (0, 0), blur)
+    return float(small.max() - np.median(small))
+
+
 #: One graded frame. ``index`` is the position in the input sequence, ``score``
-#: its sharpness, and ``source`` the original path/dict (None for raw arrays).
-FrameGrade = namedtuple("FrameGrade", ["index", "score", "source"])
+#: its sharpness, ``source`` the original path/dict (None for raw arrays), and
+#: ``content`` its :func:`content_score` (None when not computed).
+FrameGrade = namedtuple("FrameGrade", ["index", "score", "source", "content"])
 
 
 class QualityGrader:
-    """Score and rank a sequence of frames by sharpness (PIPP-style sorting)."""
+    """Score and rank a sequence of frames by sharpness (PIPP-style sorting).
 
-    def __init__(self, method="laplacian", roi=None):
+    ``scale`` (<1.0) grades at reduced resolution for speed; the ordering is
+    preserved so it is safe for ranking. When ``with_content`` is set, each grade
+    also carries a :func:`content_score` for the garbage pre-cull.
+    """
+
+    def __init__(self, method="laplacian", roi=None, scale=1.0, with_content=False):
         if method not in SHARPNESS_METHODS:
             raise ValueError(f"unknown method {method!r}")
         self.method = method
         self.roi = roi
+        self.scale = float(scale)
+        self.with_content = bool(with_content)
 
     def score(self, frame):
         arr = _as_array(frame)
-        return 0.0 if arr is None else sharpness(arr, self.method, self.roi)
+        return 0.0 if arr is None else sharpness(arr, self.method, self.roi, self.scale)
 
-    def grade(self, frames):
-        """Grade an iterable of frames, returning ``FrameGrade`` in input order."""
-        grades = []
-        for i, f in enumerate(frames):
-            src = f if not isinstance(f, np.ndarray) else None
-            grades.append(FrameGrade(i, self.score(f), src))
-        return grades
+    def _grade_one(self, i, frame):
+        arr = _as_array(frame)
+        src = frame if not isinstance(frame, np.ndarray) else None
+        if arr is None:
+            return FrameGrade(i, 0.0, src, 0.0 if self.with_content else None)
+        s = sharpness(arr, self.method, self.roi, self.scale)
+        c = content_score(arr) if self.with_content else None
+        return FrameGrade(i, s, src, c)
+
+    def grade(self, frames, workers=1):
+        """Grade frames, returning ``FrameGrade`` in input order.
+
+        ``workers`` >1 decodes+scores frames on a thread pool. OpenCV releases
+        the GIL during decode and the metric filters, so this scales close to
+        linearly with cores on the decode-bound full-frame workload.
+        """
+        frames = list(frames)
+        if workers and workers > 1 and len(frames) > 1:
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                return list(ex.map(lambda p: self._grade_one(*p), enumerate(frames)))
+        return [self._grade_one(i, f) for i, f in enumerate(frames)]
 
 
 def select_best(grades, fraction=None, count=None, min_keep=1):
@@ -190,6 +254,36 @@ def select_best(grades, fraction=None, count=None, min_keep=1):
         k = n
     k = max(int(min_keep), min(k, n))
     return ordered[:k]
+
+
+def prefilter_garbage(grades, ratio=0.12, min_keep=1):
+    """Drop only *obviously* empty/garbage frames by :func:`content_score`.
+
+    Returns ``(survivors, dropped)``. A frame is dropped when its content score
+    falls below ``ratio`` times a robust "good frame" reference (the median of
+    the top half of scores), so the cut adapts to the capture's signal level and
+    is intentionally lenient -- a faint-but-real target sits well above the floor
+    while structureless noise and blank sky fall below it. This runs *before* the
+    precise sharpness ranking so noise frames (which score high on sharpness) can
+    never sneak into the kept set. Grades lacking a content score are all kept.
+
+    ``min_keep`` guarantees at least that many survivors (the highest-content
+    frames) so a mostly-garbage capture still yields something to stack.
+    """
+    scored = [g for g in grades if g.content is not None]
+    if not scored:
+        return list(grades), []
+    vals = np.sort([g.content for g in scored])
+    ref = float(np.median(vals[len(vals) // 2:]))  # median of the top half
+    floor = ratio * ref
+    survivors = [g for g in grades if g.content is None or g.content >= floor]
+    dropped = [g for g in grades if g.content is not None and g.content < floor]
+    if len(survivors) < min_keep:  # keep the best-content frames regardless
+        keep = sorted(scored, key=lambda g: g.content, reverse=True)[:min_keep]
+        keep_ids = {id(g) for g in keep}
+        survivors = [g for g in grades if id(g) in keep_ids]
+        dropped = [g for g in grades if id(g) not in keep_ids]
+    return survivors, dropped
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +552,8 @@ class LuckyStacker:
     """
 
     def __init__(self, method="orb", local=False, ap_spacing=80, ap_patch=48,
-                 full_affine=False, min_local_response=0.0, max_local_shift=None):
+                 full_affine=False, min_local_response=0.0, max_local_shift=None,
+                 align_scale=1.0):
         _require_cv2()
         self.method = method
         self.local = bool(local)
@@ -469,6 +564,12 @@ class LuckyStacker:
         # Default cap on a single alignment point's shift: a quarter of the patch.
         self.max_local_shift = (self.ap_patch / 4.0 if max_local_shift is None
                                 else float(max_local_shift))
+        # <1.0 estimates the global transform on a downscaled frame (feature
+        # detection is the dominant cost and scales ~quadratically), then warps
+        # the FULL-res frame -- so the master stays full resolution. Only the
+        # global-shift *estimate* loses precision; measured quality loss is small
+        # (see tests), but 1.0 is the default when maximum sharpness matters.
+        self.align_scale = float(align_scale)
 
         self._stab = None
         self._ref_gray = None
@@ -479,23 +580,84 @@ class LuckyStacker:
         self.n_rejected = 0
 
     # ------------------------------------------------------------- reference
-    def set_reference(self, frame):
-        """Anchor the stack on ``frame`` (also the first stacked frame)."""
+    def set_reference(self, frame, seed_stack=True):
+        """Anchor the stack on ``frame``.
+
+        With ``seed_stack`` (default) the reference is also the first stacked
+        frame. Pass ``seed_stack=False`` to build only the alignment anchor with
+        an empty accumulator -- used by the parallel map-reduce path so several
+        worker stackers can share one reference without counting it N times; one
+        worker seeds it, the rest start empty and are :meth:`merge`\\ d in.
+        """
         arr = _as_array(frame)
         if arr is None:
             raise ValueError("reference frame could not be decoded")
         self._stab = Stabilizer(method=self.method, full_affine=self.full_affine)
-        self._stab.set_reference(arr)
+        # Detect features at align_scale so incoming frames match; keep the
+        # full-res gray for local alignment-point measurement.
+        self._stab.set_reference(self._align_gray(arr))
         self._ref_gray = _to_gray(arr).astype(np.float32)
-        self._accum = arr.astype(np.float64).copy()
-        self._weight = np.ones(arr.shape[:2], dtype=np.float64)  # full coverage
-        self._count = 1
+        if seed_stack:
+            self._accum = arr.astype(np.float64).copy()
+            self._weight = np.ones(arr.shape[:2], dtype=np.float64)  # full coverage
+            self._count = 1
+        else:
+            self._accum = np.zeros(arr.shape, dtype=np.float64)
+            self._weight = np.zeros(arr.shape[:2], dtype=np.float64)
+            self._count = 0
         if self.local:
             self._grid = AlignmentPointGrid.over(arr.shape, self.ap_spacing)
+
+    def merge(self, other):
+        """Fold another stacker's partial sums into this one (map-reduce join).
+
+        Both must share the same reference frame shape. Used to recombine the
+        per-worker partial stacks produced by the parallel path.
+        """
+        if other._accum is None:
+            return self
+        if self._accum is None:
+            self._accum = other._accum.copy()
+            self._weight = other._weight.copy()
+        else:
+            self._accum += other._accum
+            self._weight += other._weight
+        self._count += other._count
+        self.n_rejected += other.n_rejected
+        return self
 
     @property
     def has_reference(self):
         return self._stab is not None and self._stab.has_reference
+
+    def _align_gray(self, arr):
+        """Gray frame at the alignment scale (identity RGB when align_scale==1)."""
+        if self.align_scale == 1.0:
+            return arr
+        g = _to_gray(arr)
+        nh = max(1, int(g.shape[0] * self.align_scale))
+        nw = max(1, int(g.shape[1] * self.align_scale))
+        return cv2.resize(g, (nw, nh), interpolation=cv2.INTER_AREA)
+
+    def _align(self, arr):
+        """Return (warped_full_res, M_full_res, ok) aligning ``arr`` to the ref."""
+        if self.align_scale == 1.0:
+            warped, M = self._stab.stabilize(arr)
+            return warped, M, self._stab.last_ok
+        # Estimate on the downscaled frame, then apply to the full-res frame.
+        M, _ = self._stab.estimate_transform(self._align_gray(arr))
+        if M is None:
+            return None, None, False
+        M = M.copy()
+        M[0, 2] /= self.align_scale     # only translation is resolution-dependent
+        M[1, 2] /= self.align_scale
+        if not self._stab._validate(M, arr.shape):
+            return None, None, False
+        h, w = arr.shape[:2]
+        warped = cv2.warpAffine(
+            arr, M.astype(np.float32), (w, h), flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_CONSTANT, borderValue=(0, 0, 0))
+        return warped, M, True
 
     # --------------------------------------------------------------- adding
     def add(self, frame):
@@ -514,8 +676,8 @@ class LuckyStacker:
             self.n_rejected += 1
             return False
 
-        warped, M = self._stab.stabilize(arr)
-        if not self._stab.last_ok:
+        warped, M, ok = self._align(arr)
+        if not ok:
             self.n_rejected += 1
             return False
 
@@ -562,23 +724,80 @@ class LuckyStacker:
 # Run-level glue: PIPP -> AutoStakkert over an on-disk Run
 # ---------------------------------------------------------------------------
 StackResult = namedtuple(
-    "StackResult", ["master", "stats", "grades", "kept", "reference_index"])
+    "StackResult",
+    ["master", "stats", "grades", "kept", "reference_index", "dropped"])
+
+
+def _stack_parallel(ref_arr, frame_specs, method, local, workers, on_advance=None,
+                    align_scale=1.0):
+    """Map-reduce stack: K workers each align+accumulate a slice, then merge.
+
+    All workers share one alignment reference (built K times, a one-off cost);
+    only worker 0 seeds the reference into its accumulator so the merged master
+    counts it exactly once. Accumulation is per-worker (no shared mutable state),
+    so there is no lock on the hot path -- the partial float sums are added at
+    the end. OpenCV releases the GIL during detect/warp, so this scales with
+    cores on the align-bound stack pass.
+    """
+    n = len(frame_specs)
+    k = max(1, min(int(workers or 1), n if n else 1))
+    stackers = []
+    for i in range(k):
+        s = LuckyStacker(method=method, local=local, align_scale=align_scale)
+        s.set_reference(ref_arr, seed_stack=(i == 0))
+        stackers.append(s)
+    chunks = [frame_specs[i::k] for i in range(k)]
+
+    def work(i):
+        s = stackers[i]
+        for spec in chunks[i]:
+            s.add(spec)
+            if on_advance:
+                on_advance()
+        return s
+
+    if k == 1:
+        work(0)
+    else:
+        # Trim OpenCV's own thread pool so K Python workers don't oversubscribe.
+        old = cv2.getNumThreads()
+        cv2.setNumThreads(max(1, old // k))
+        try:
+            with ThreadPoolExecutor(max_workers=k) as ex:
+                list(ex.map(work, range(k)))
+        finally:
+            cv2.setNumThreads(old)
+
+    master = stackers[0]
+    for s in stackers[1:]:
+        master.merge(s)
+    return master
 
 
 def stack_run(run, cam_index, keep_fraction=0.5, keep_count=None,
               quality="laplacian", method="orb", local=False, roi=None,
-              t_start=None, t_end=None, max_frames=None, progress=None):
+              t_start=None, t_end=None, max_frames=None, progress=None,
+              workers=None, grade_scale=1.0, prefilter=True, prefilter_ratio=0.12,
+              align_scale=1.0):
     """Run the full lucky-imaging pipeline over one camera of a :class:`Run`.
 
-    Steps: gather frames in the (optional) ``[t_start, t_end]`` window, grade
-    them by ``quality`` sharpness (optionally within ``roi``), keep the sharpest
-    ``keep_fraction`` (or ``keep_count``), use the single sharpest frame as the
-    alignment reference, then align + average the kept set with
-    :class:`LuckyStacker`.
+    Two-tier culling keeps a fast first pass from throwing away good data:
+
+    1. **Grade** every frame in the ``[t_start, t_end]`` window in parallel --
+       a precise ``quality`` sharpness score (optionally at ``grade_scale`` for
+       speed, within ``roi``) plus a noise-robust :func:`content_score`.
+    2. **Pre-cull garbage** (``prefilter``): drop only frames with essentially no
+       signal (blank sky, structureless noise) via :func:`prefilter_garbage`.
+       This must precede ranking because sharpness *rewards* noise, so a naive
+       top-X% would otherwise keep hot-pixel/noise frames and discard faint but
+       real ones.
+    3. **Rank & keep** the sharpest ``keep_fraction`` (or ``keep_count``) of the
+       survivors; the single sharpest anchors the alignment.
+    4. **Align + average** the kept set into a high-SNR master, fanned out across
+       ``workers`` cores (defaults to all).
 
     ``progress`` is an optional ``callback(done, total)`` for UIs. Returns a
-    :class:`StackResult` whose ``master`` is the stacked image (None if no usable
-    frames).
+    :class:`StackResult`; ``dropped`` lists the frames the pre-cull removed.
     """
     frames = run.frames(cam_index)
     if t_start is not None or t_end is not None:
@@ -591,27 +810,45 @@ def stack_run(run, cam_index, keep_fraction=0.5, keep_count=None,
         idx = np.linspace(0, len(frames) - 1, int(max_frames)).round().astype(int)
         frames = [frames[i] for i in sorted(set(idx.tolist()))]
 
-    grader = QualityGrader(method=quality, roi=roi)
-    grades = grader.grade(frames)
-    if not grades:
-        return StackResult(None, StackStats(0, 0, 0), [], [], None)
+    if workers is None:
+        workers = max(1, os.cpu_count() or 1)
 
-    kept = select_best(grades,
+    grader = QualityGrader(method=quality, roi=roi, scale=grade_scale,
+                           with_content=prefilter)
+    grades = grader.grade(frames, workers=workers)
+    if not grades:
+        return StackResult(None, StackStats(0, 0, 0), [], [], None, [])
+
+    if prefilter:
+        survivors, dropped = prefilter_garbage(grades, ratio=prefilter_ratio)
+    else:
+        survivors, dropped = list(grades), []
+
+    kept = select_best(survivors,
                        fraction=keep_fraction if keep_count is None else None,
                        count=keep_count)
-    reference_index = kept[0].index  # sharpest frame anchors the stack
+    reference_index = kept[0].index  # sharpest survivor anchors the stack
+    ref_arr = _as_array(frames[reference_index])  # decode the reference once
 
-    stacker = LuckyStacker(method=method, local=local)
-    stacker.set_reference(frames[reference_index]["path"])
     total = len(kept)
+    counter = {"n": 1}
+    lock = threading.Lock()
     if progress:
         progress(1, total)
-    for n, g in enumerate(kept[1:], start=2):
-        stacker.add(frames[g.index]["path"])
-        if progress:
-            progress(n, total)
 
-    return StackResult(stacker.result(), stacker.stats, grades, kept, reference_index)
+    def advance():
+        if not progress:
+            return
+        with lock:
+            counter["n"] += 1
+            progress(counter["n"], total)
+
+    to_stack = [frames[g.index] for g in kept[1:]]
+    stacker = _stack_parallel(ref_arr, to_stack, method, local, workers, advance,
+                              align_scale=align_scale)
+
+    return StackResult(stacker.result(), stacker.stats, grades, kept,
+                       reference_index, dropped)
 
 
 def save_master(master, out_path):

--- a/stacking.py
+++ b/stacking.py
@@ -1,0 +1,587 @@
+"""Lucky-imaging post-processing: PIPP-style prep + AutoStakkert-style stacking.
+
+This module adds the planetary / lunar / satellite "lucky imaging" pipeline to
+the post-processing core. It follows the same two-tool mental model the rest of
+the project uses (see ``post_process.py``):
+
+PIPP stage -- *prep & conditioning* (tidy and align)
+    * :func:`sharpness` / :class:`QualityGrader`
+        estimate per-frame sharpness and rank frames worst-to-best.
+    * :func:`select_best`
+        cull down to the sharpest top X% (or top N) -- "lucky" frame selection.
+    * :func:`brightness_centroid` / :func:`bounding_box`
+        find the target (a bright blob on a dark sky).
+    * :func:`crop_centered` / :func:`recenter_frame`
+        re-centre the target on the canvas and/or crop a small box around it,
+        which is the big win for a fast-moving target like the ISS.
+
+AutoStakkert stage -- *stacking* (combine the best frames)
+    * :class:`AlignmentPointGrid` + :func:`measure_local_shifts`
+        a regular grid of alignment points and the per-point sub-pixel shift of
+        a frame vs a reference -- i.e. the local distortion from seeing.
+    * :class:`LuckyStacker`
+        align the selected frames to a reference and average them into one
+        high-SNR master, optionally correcting local distortion via the
+        alignment-point grid. Averaging beats down random noise so detail buried
+        in any single frame emerges.
+    * :func:`stack_run`
+        glue that runs the whole PIPP->AutoStakkert flow over an on-disk
+        :class:`post_process.Run`.
+
+Everything is pure numpy / OpenCV so it runs headless and is unit-testable, and
+it composes with the existing :class:`stabilizer.Stabilizer` (global rigid
+alignment) and the on-disk frame indexing in :class:`post_process.Run`.
+"""
+
+import os
+from collections import namedtuple
+
+import numpy as np
+
+try:
+    import cv2
+    CV2_AVAILABLE = True
+except ImportError:  # pragma: no cover - cv2 is expected in the track env
+    cv2 = None
+    CV2_AVAILABLE = False
+
+from stabilizer import Stabilizer, _to_gray
+
+
+# ---------------------------------------------------------------------------
+# Small shared helpers
+# ---------------------------------------------------------------------------
+def _require_cv2():
+    if not CV2_AVAILABLE:
+        raise RuntimeError("OpenCV (cv2) is required for stacking")
+
+
+def _decode(path):
+    """Decode an image file to an RGB uint8 array (None on failure)."""
+    if not CV2_AVAILABLE:
+        return None
+    bgr = cv2.imread(path, cv2.IMREAD_COLOR)
+    if bgr is None:
+        return None
+    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+
+def _as_array(frame):
+    """Coerce a frame spec (ndarray | path str | {'path': ...}) to an ndarray."""
+    if frame is None:
+        return None
+    if isinstance(frame, np.ndarray):
+        return frame
+    if isinstance(frame, str):
+        return _decode(frame)
+    if isinstance(frame, dict) and "path" in frame:
+        return _decode(frame["path"])
+    raise TypeError(f"cannot coerce {type(frame)!r} to a frame array")
+
+
+def _clamp_roi(shape, roi):
+    """Clamp an (x, y, w, h) ROI to the image, returning a valid sub-box."""
+    h, w = shape[:2]
+    x, y, rw, rh = (int(v) for v in roi)
+    x0 = max(0, min(x, w - 1))
+    y0 = max(0, min(y, h - 1))
+    x1 = max(x0 + 1, min(x + rw, w))
+    y1 = max(y0 + 1, min(y + rh, h))
+    return x0, y0, x1 - x0, y1 - y0
+
+
+# ---------------------------------------------------------------------------
+# PIPP stage: quality estimation + frame grading / culling
+# ---------------------------------------------------------------------------
+SHARPNESS_METHODS = ("laplacian", "tenengrad", "fft")
+
+
+def sharpness(frame, method="laplacian", roi=None):
+    """Estimate a frame's sharpness as a single non-negative score.
+
+    Higher means sharper. The score is only meaningful *relative* to other
+    frames of the same scene, which is exactly how it is used for grading.
+
+    method
+        ``"laplacian"`` -- variance of the Laplacian (cheap, robust default).
+        ``"tenengrad"`` -- mean squared Sobel gradient magnitude (edge energy).
+        ``"fft"``       -- fraction of spectral energy in the high-frequency
+                           band; less sensitive to overall brightness/contrast.
+    roi
+        optional (x, y, w, h) sub-box (full-frame px) to score only the target
+        region -- keeps a bright, sharp target from being averaged out by a
+        large empty sky.
+    """
+    _require_cv2()
+    gray = _to_gray(frame)
+    if roi is not None:
+        x, y, w, h = _clamp_roi(gray.shape, roi)
+        gray = gray[y:y + h, x:x + w]
+    if gray.size == 0:
+        return 0.0
+    if method == "laplacian":
+        return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+    if method == "tenengrad":
+        gx = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
+        gy = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
+        return float(np.mean(gx * gx + gy * gy))
+    if method == "fft":
+        return _fft_sharpness(gray)
+    raise ValueError(f"unknown sharpness method {method!r}; choose from {SHARPNESS_METHODS}")
+
+
+def _fft_sharpness(gray):
+    """High-frequency energy fraction of the magnitude spectrum (0..1-ish)."""
+    f = np.fft.fftshift(np.fft.fft2(gray.astype(np.float64)))
+    mag = np.abs(f)
+    h, w = gray.shape
+    cy, cx = h / 2.0, w / 2.0
+    yy, xx = np.ogrid[:h, :w]
+    r = np.hypot(yy - cy, xx - cx)
+    rmax = np.hypot(cy, cx) + 1e-9
+    high = float(mag[r > 0.25 * rmax].sum())
+    total = float(mag.sum()) + 1e-9
+    return high / total
+
+
+#: One graded frame. ``index`` is the position in the input sequence, ``score``
+#: its sharpness, and ``source`` the original path/dict (None for raw arrays).
+FrameGrade = namedtuple("FrameGrade", ["index", "score", "source"])
+
+
+class QualityGrader:
+    """Score and rank a sequence of frames by sharpness (PIPP-style sorting)."""
+
+    def __init__(self, method="laplacian", roi=None):
+        if method not in SHARPNESS_METHODS:
+            raise ValueError(f"unknown method {method!r}")
+        self.method = method
+        self.roi = roi
+
+    def score(self, frame):
+        arr = _as_array(frame)
+        return 0.0 if arr is None else sharpness(arr, self.method, self.roi)
+
+    def grade(self, frames):
+        """Grade an iterable of frames, returning ``FrameGrade`` in input order."""
+        grades = []
+        for i, f in enumerate(frames):
+            arr = _as_array(f)
+            s = 0.0 if arr is None else sharpness(arr, self.method, self.roi)
+            src = f if not isinstance(f, np.ndarray) else None
+            grades.append(FrameGrade(i, s, src))
+        return grades
+
+
+def select_best(grades, fraction=None, count=None, min_keep=1):
+    """Pick the highest-scoring grades, sharpest first (the "lucky" frames).
+
+    Provide ``fraction`` (e.g. 0.25 keeps the best 25%) or ``count`` (keep N).
+    With neither, all grades are returned sorted best-first. ``min_keep`` floors
+    the result so an aggressive fraction never yields zero frames.
+    """
+    ordered = sorted(grades, key=lambda g: g.score, reverse=True)
+    n = len(ordered)
+    if n == 0:
+        return []
+    if count is not None:
+        k = int(count)
+    elif fraction is not None:
+        k = int(round(fraction * n))
+    else:
+        k = n
+    k = max(int(min_keep), min(k, n))
+    return ordered[:k]
+
+
+# ---------------------------------------------------------------------------
+# PIPP stage: target finding, centering, cropping
+# ---------------------------------------------------------------------------
+def _foreground(gray, threshold):
+    """Background-subtracted foreground weights (>=0) and the threshold used."""
+    g = gray.astype(np.float64)
+    if threshold is None:
+        threshold = float(g.mean() + 2.0 * g.std())
+    return np.clip(g - threshold, 0.0, None), threshold
+
+
+def brightness_centroid(frame, threshold=None, roi=None):
+    """Intensity-weighted centroid (cx, cy) of the bright target, or None.
+
+    Pixels at or below ``threshold`` (default ``mean + 2*std``) are treated as
+    sky and ignored, so the centroid locks onto the target rather than drifting
+    toward the frame centre. Returns float pixel coords in full-frame space.
+    """
+    _require_cv2()
+    gray = _to_gray(frame)
+    x0 = y0 = 0
+    if roi is not None:
+        x0, y0, rw, rh = _clamp_roi(gray.shape, roi)
+        gray = gray[y0:y0 + rh, x0:x0 + rw]
+    weights, _ = _foreground(gray, threshold)
+    total = float(weights.sum())
+    if total <= 0.0:
+        return None
+    h, w = gray.shape
+    ys, xs = np.mgrid[0:h, 0:w]
+    cx = float((xs * weights).sum() / total) + x0
+    cy = float((ys * weights).sum() / total) + y0
+    return cx, cy
+
+
+def bounding_box(frame, threshold=None, pad=0):
+    """Tight (x, y, w, h) box around the bright target, padded, or None.
+
+    Useful for PIPP-style cropping: shrink each frame to a small box around the
+    target to cut file size and speed up everything downstream.
+    """
+    _require_cv2()
+    gray = _to_gray(frame).astype(np.float64)
+    if threshold is None:
+        threshold = float(gray.mean() + 2.0 * gray.std())
+    mask = gray > threshold
+    if not mask.any():
+        return None
+    ys, xs = np.where(mask)
+    x0, x1 = int(xs.min()), int(xs.max())
+    y0, y1 = int(ys.min()), int(ys.max())
+    h, w = gray.shape
+    x0 = max(0, x0 - pad)
+    y0 = max(0, y0 - pad)
+    x1 = min(w - 1, x1 + pad)
+    y1 = min(h - 1, y1 + pad)
+    return x0, y0, x1 - x0 + 1, y1 - y0 + 1
+
+
+def crop_centered(frame, center, size, pad_value=0):
+    """Crop a fixed ``size`` box centred on ``center``, padding off-frame edges.
+
+    ``size`` may be an int (square) or (w, h). The output is always exactly
+    ``size`` regardless of how close ``center`` sits to an edge -- revealed area
+    is filled with ``pad_value`` -- so cropped frames stack without resizing.
+    """
+    arr = np.asarray(frame)
+    if isinstance(size, (int, float)):
+        out_w = out_h = int(size)
+    else:
+        out_w, out_h = int(size[0]), int(size[1])
+    cx, cy = float(center[0]), float(center[1])
+
+    shape = (out_h, out_w) + arr.shape[2:]
+    canvas = np.full(shape, pad_value, dtype=arr.dtype)
+
+    # Source top-left so that ``center`` lands at the output centre.
+    sx0 = int(round(cx - out_w / 2.0))
+    sy0 = int(round(cy - out_h / 2.0))
+    src_h, src_w = arr.shape[:2]
+
+    # Overlap of the requested source window with the actual image.
+    ix0 = max(0, sx0)
+    iy0 = max(0, sy0)
+    ix1 = min(src_w, sx0 + out_w)
+    iy1 = min(src_h, sy0 + out_h)
+    if ix1 <= ix0 or iy1 <= iy0:
+        return canvas  # target window entirely off-frame
+    # Where that overlap lands in the output canvas.
+    ox0 = ix0 - sx0
+    oy0 = iy0 - sy0
+    canvas[oy0:oy0 + (iy1 - iy0), ox0:ox0 + (ix1 - ix0)] = arr[iy0:iy1, ix0:ix1]
+    return canvas
+
+
+def recenter_frame(frame, center=None, out_size=None, threshold=None, pad_value=0):
+    """Shift the target to the canvas centre (PIPP centring / stabilising).
+
+    ``center`` defaults to :func:`brightness_centroid`; if the target cannot be
+    found the frame is returned (cropped to ``out_size`` about its geometric
+    centre) so a blank frame never derails a batch. ``out_size`` defaults to the
+    input size.
+    """
+    arr = np.asarray(frame)
+    h, w = arr.shape[:2]
+    if out_size is None:
+        out_size = (w, h)
+    if center is None:
+        center = brightness_centroid(arr, threshold=threshold)
+    if center is None:
+        center = (w / 2.0, h / 2.0)
+    return crop_centered(arr, center, out_size, pad_value=pad_value)
+
+
+# ---------------------------------------------------------------------------
+# AutoStakkert stage: alignment points (local distortion from seeing)
+# ---------------------------------------------------------------------------
+class AlignmentPointGrid:
+    """A regular grid of alignment points laid over a frame.
+
+    AutoStakkert places many alignment points across the target and tracks how
+    each moves frame-to-frame, correcting *local* distortion from seeing rather
+    than just a whole-frame shift. Keeping the points on a regular grid lets the
+    measured per-point shifts be reshaped to ``(rows, cols)`` and upsampled into
+    a dense displacement field with a single :func:`cv2.resize` -- no scattered
+    interpolation dependency.
+    """
+
+    def __init__(self, points, rows, cols, shape):
+        self.points = np.asarray(points, dtype=np.float64)  # (rows*cols, 2) x,y
+        self.rows = int(rows)
+        self.cols = int(cols)
+        self.shape = tuple(shape[:2])
+
+    def __len__(self):
+        return len(self.points)
+
+    @classmethod
+    def over(cls, shape, spacing=80, margin=None):
+        """Build a grid spanning ``shape`` (h, w) at roughly ``spacing`` px apart.
+
+        At least a 2x2 grid is produced so the displacement field can be
+        bilinearly upsampled.
+        """
+        h, w = shape[:2]
+        spacing = max(1, int(spacing))
+        if margin is None:
+            margin = spacing // 2
+        margin = int(max(0, min(margin, (min(h, w) - 1) // 2)))
+        cols = max(2, 1 + (w - 2 * margin) // spacing)
+        rows = max(2, 1 + (h - 2 * margin) // spacing)
+        xs = np.linspace(margin, w - 1 - margin, cols)
+        ys = np.linspace(margin, h - 1 - margin, rows)
+        gx, gy = np.meshgrid(xs, ys)
+        points = np.column_stack([gx.ravel(), gy.ravel()])
+        return cls(points, rows, cols, shape)
+
+
+def measure_local_shifts(ref_gray, frame_gray, points, patch=48, min_response=0.0):
+    """Per-point sub-pixel shift of ``frame`` vs ``ref`` at each alignment point.
+
+    For each point a square patch (side ``patch``) is cut from both images and
+    registered with phase correlation. The returned ``(N, 2)`` array holds the
+    ``(dx, dy)`` that maps a reference location to where that content sits in the
+    frame -- i.e. ``frame`` sampled at ``ref_xy + shift`` lands back on ``ref``.
+    Points whose correlation response is below ``min_response`` (or that fall too
+    near an edge) report a zero shift.
+    """
+    _require_cv2()
+    ref = ref_gray if ref_gray.ndim == 2 else _to_gray(ref_gray)
+    cur = frame_gray if frame_gray.ndim == 2 else _to_gray(frame_gray)
+    ref = ref.astype(np.float32)
+    cur = cur.astype(np.float32)
+    h, w = ref.shape
+    half = int(patch) // 2
+    win = cv2.createHanningWindow((2 * half, 2 * half), cv2.CV_32F)
+
+    side = 2 * half
+    if side > w or side > h:
+        return np.zeros((len(points), 2), dtype=np.float64)  # patch bigger than image
+
+    shifts = np.zeros((len(points), 2), dtype=np.float64)
+    for i, (px, py) in enumerate(points):
+        # Clamp the patch fully inside the image (points near the edge sample a
+        # slightly off-centre window rather than being dropped, so every grid
+        # node still contributes to the displacement field).
+        x0 = int(np.clip(round(px) - half, 0, w - side))
+        y0 = int(np.clip(round(py) - half, 0, h - side))
+        a = ref[y0:y0 + 2 * half, x0:x0 + 2 * half]
+        b = cur[y0:y0 + 2 * half, x0:x0 + 2 * half]
+        (dx, dy), response = cv2.phaseCorrelate(a, b, win)
+        if response < min_response:
+            continue
+        shifts[i] = (dx, dy)
+    return shifts
+
+
+def warp_by_grid(frame, grid, shifts, border=None):
+    """Remap ``frame`` by a dense field interpolated from per-point ``shifts``.
+
+    The coarse ``(rows, cols)`` shift grid is upsampled to full resolution and
+    used as a displacement field: output pixel ``(x, y)`` samples the input at
+    ``(x + dx, y + dy)``. This undoes the local distortion measured by
+    :func:`measure_local_shifts` so the warped frame lines up with the reference
+    before it is added to the stack.
+    """
+    _require_cv2()
+    if border is None:
+        border = cv2.BORDER_REFLECT
+    h, w = frame.shape[:2]
+    dx = shifts[:, 0].reshape(grid.rows, grid.cols).astype(np.float32)
+    dy = shifts[:, 1].reshape(grid.rows, grid.cols).astype(np.float32)
+    dx_full = cv2.resize(dx, (w, h), interpolation=cv2.INTER_LINEAR)
+    dy_full = cv2.resize(dy, (w, h), interpolation=cv2.INTER_LINEAR)
+    base_x, base_y = np.meshgrid(np.arange(w, dtype=np.float32),
+                                 np.arange(h, dtype=np.float32))
+    map_x = base_x + dx_full
+    map_y = base_y + dy_full
+    return cv2.remap(frame, map_x, map_y, interpolation=cv2.INTER_LINEAR,
+                     borderMode=border)
+
+
+# ---------------------------------------------------------------------------
+# AutoStakkert stage: the stacker
+# ---------------------------------------------------------------------------
+StackStats = namedtuple("StackStats", ["n_total", "n_stacked", "n_rejected"])
+
+
+class LuckyStacker:
+    """Align frames to a reference and average them into one high-SNR master.
+
+    This is the AutoStakkert core. Each incoming frame is globally aligned to a
+    fixed reference (via :class:`stabilizer.Stabilizer`, RANSAC similarity), and
+    -- when ``local=True`` -- additionally corrected for seeing distortion with
+    an :class:`AlignmentPointGrid`. Aligned frames are summed in float; the mean
+    is the low-noise master. Frames that fail to align are dropped (counted in
+    :attr:`stats`) rather than smeared into the result.
+
+    Typical use is to feed only the sharpest top X% (see :func:`select_best`),
+    with the sharpest frame as the reference.
+    """
+
+    def __init__(self, method="orb", local=False, ap_spacing=80, ap_patch=48,
+                 full_affine=False, min_local_response=0.0):
+        _require_cv2()
+        self.method = method
+        self.local = bool(local)
+        self.ap_spacing = int(ap_spacing)
+        self.ap_patch = int(ap_patch)
+        self.full_affine = bool(full_affine)
+        self.min_local_response = float(min_local_response)
+
+        self._stab = None
+        self._ref_gray = None
+        self._grid = None
+        self._accum = None
+        self._count = 0
+        self.n_total = 0
+        self.n_rejected = 0
+
+    # ------------------------------------------------------------- reference
+    def set_reference(self, frame):
+        """Anchor the stack on ``frame`` (also the first stacked frame)."""
+        arr = _as_array(frame)
+        if arr is None:
+            raise ValueError("reference frame could not be decoded")
+        self._stab = Stabilizer(method=self.method, full_affine=self.full_affine)
+        self._stab.set_reference(arr)
+        self._ref_gray = _to_gray(arr).astype(np.float32)
+        self._accum = arr.astype(np.float64).copy()
+        self._count = 1
+        if self.local:
+            self._grid = AlignmentPointGrid.over(arr.shape, self.ap_spacing)
+
+    @property
+    def has_reference(self):
+        return self._stab is not None and self._stab.has_reference
+
+    # --------------------------------------------------------------- adding
+    def add(self, frame):
+        """Align ``frame`` to the reference and add it. Returns True if stacked.
+
+        The first ``add`` with no reference set adopts the frame as reference.
+        """
+        arr = _as_array(frame)
+        self.n_total += 1
+        if arr is None:
+            self.n_rejected += 1
+            return False
+        if not self.has_reference:
+            self.set_reference(arr)
+            return True
+
+        warped, _ = self._stab.stabilize(arr)
+        if not self._stab.last_ok:
+            self.n_rejected += 1
+            return False
+        if self.local and self._grid is not None:
+            shifts = measure_local_shifts(
+                self._ref_gray, _to_gray(warped), self._grid.points,
+                patch=self.ap_patch, min_response=self.min_local_response)
+            warped = warp_by_grid(warped, self._grid, shifts)
+        self._accum += warped.astype(np.float64)
+        self._count += 1
+        return True
+
+    def stack(self, frames):
+        """Convenience: ``add`` every frame in ``frames`` and return the master."""
+        for f in frames:
+            self.add(f)
+        return self.result()
+
+    # --------------------------------------------------------------- output
+    def result(self):
+        """The averaged master frame (uint8 RGB), or None if nothing stacked."""
+        if self._count == 0 or self._accum is None:
+            return None
+        return np.clip(self._accum / self._count, 0, 255).astype(np.uint8)
+
+    @property
+    def stats(self):
+        return StackStats(self.n_total, self._count, self.n_rejected)
+
+
+# ---------------------------------------------------------------------------
+# Run-level glue: PIPP -> AutoStakkert over an on-disk Run
+# ---------------------------------------------------------------------------
+StackResult = namedtuple(
+    "StackResult", ["master", "stats", "grades", "kept", "reference_index"])
+
+
+def stack_run(run, cam_index, keep_fraction=0.5, keep_count=None,
+              quality="laplacian", method="orb", local=False, roi=None,
+              t_start=None, t_end=None, max_frames=None, progress=None):
+    """Run the full lucky-imaging pipeline over one camera of a :class:`Run`.
+
+    Steps: gather frames in the (optional) ``[t_start, t_end]`` window, grade
+    them by ``quality`` sharpness (optionally within ``roi``), keep the sharpest
+    ``keep_fraction`` (or ``keep_count``), use the single sharpest frame as the
+    alignment reference, then align + average the kept set with
+    :class:`LuckyStacker`.
+
+    ``progress`` is an optional ``callback(done, total)`` for UIs. Returns a
+    :class:`StackResult` whose ``master`` is the stacked image (None if no usable
+    frames).
+    """
+    frames = run.frames(cam_index)
+    if t_start is not None or t_end is not None:
+        lo = -np.inf if t_start is None else t_start
+        hi = np.inf if t_end is None else t_end
+        lo, hi = min(lo, hi), max(lo, hi)
+        frames = [f for f in frames if lo <= f["t"] <= hi]
+    if max_frames is not None and len(frames) > max_frames:
+        # Evenly subsample so the graded set still spans the whole capture.
+        idx = np.linspace(0, len(frames) - 1, int(max_frames)).round().astype(int)
+        frames = [frames[i] for i in sorted(set(idx.tolist()))]
+
+    grader = QualityGrader(method=quality, roi=roi)
+    grades = grader.grade(frames)
+    if not grades:
+        return StackResult(None, StackStats(0, 0, 0), [], [], None)
+
+    kept = select_best(grades, fraction=None if keep_count else keep_fraction,
+                       count=keep_count)
+    reference_index = kept[0].index  # sharpest frame anchors the stack
+
+    stacker = LuckyStacker(method=method, local=local)
+    stacker.set_reference(frames[reference_index]["path"])
+    total = len(kept)
+    if progress:
+        progress(1, total)
+    for n, g in enumerate(kept[1:], start=2):
+        stacker.add(frames[g.index]["path"])
+        if progress:
+            progress(n, total)
+
+    return StackResult(stacker.result(), stacker.stats, grades, kept, reference_index)
+
+
+def save_master(master, out_path):
+    """Write a stacked master (RGB uint8) to disk as PNG/TIFF/etc. by extension."""
+    _require_cv2()
+    if master is None:
+        raise ValueError("no master image to save")
+    ext = os.path.splitext(out_path)[1].lower()
+    if ext not in (".png", ".tif", ".tiff", ".bmp", ".jpg", ".jpeg"):
+        out_path = out_path + ".png"
+    bgr = cv2.cvtColor(master, cv2.COLOR_RGB2BGR)
+    if not cv2.imwrite(out_path, bgr):
+        raise RuntimeError(f"could not write master image to {out_path}")
+    return out_path

--- a/test_stacking.py
+++ b/test_stacking.py
@@ -1,0 +1,414 @@
+"""Headless tests for the lucky-imaging pipeline (stacking.py).
+
+PIPP-style prep (sharpness grading, culling, target centring/cropping) and
+AutoStakkert-style stacking (global + alignment-point alignment, averaging into
+a high-SNR master). Everything is synthesised in-memory so these run with no
+real ``data/`` capture and no UI.
+
+Run with the track env:
+    C:\\Users\\nikke\\anaconda3\\envs\\track\\python.exe test_stacking.py
+or just ``python test_stacking.py`` / ``pytest test_stacking.py``.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import cv2
+
+from stacking import (
+    sharpness, SHARPNESS_METHODS, QualityGrader, FrameGrade, select_best,
+    brightness_centroid, bounding_box, crop_centered, recenter_frame,
+    AlignmentPointGrid, measure_local_shifts, warp_by_grid,
+    LuckyStacker, stack_run, save_master, _decode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic scene helpers
+# ---------------------------------------------------------------------------
+def _blob(size=200, center=None, radius=14, amp=200, bg=18, blur=0.0, seed=0):
+    """A bright Gaussian blob (a 'satellite') on a dim noisy sky."""
+    h = w = size
+    if center is None:
+        center = (w / 2.0, h / 2.0)
+    yy, xx = np.mgrid[0:h, 0:w]
+    g = amp * np.exp(-(((xx - center[0]) ** 2 + (yy - center[1]) ** 2) /
+                       (2.0 * radius ** 2)))
+    rng = np.random.default_rng(seed)
+    img = bg + g + rng.normal(0, 4, (h, w))
+    img = np.clip(img, 0, 255).astype(np.uint8)
+    if blur > 0:
+        k = max(3, int(blur) | 1)
+        img = cv2.GaussianBlur(img, (k, k), blur)
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+
+
+def _textured(size=200, seed=0, blur=0.0):
+    """A high-frequency textured frame, optionally blurred (less sharp)."""
+    rng = np.random.default_rng(seed)
+    img = (rng.random((size, size)) * 255).astype(np.uint8)
+    if blur > 0:
+        k = max(3, int(blur) | 1)
+        img = cv2.GaussianBlur(img, (k, k), blur)
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+
+
+def _starfield(size=160, n_stars=45, target=True, seed=0):
+    """A noiseless starfield (+ central target blob) -- ground truth to stack.
+
+    Many small bright dots give ORB/optical-flow real features to lock onto, so
+    global alignment behaves like it does on a real sky, while the fixed dot
+    positions act as ground truth for measuring stack error.
+    """
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:size, 0:size]
+    img = np.full((size, size), 14.0)
+    for _ in range(n_stars):
+        sx = rng.integers(14, size - 14)
+        sy = rng.integers(14, size - 14)
+        amp = rng.uniform(120, 255)
+        r = rng.uniform(1.1, 2.2)
+        img += amp * np.exp(-(((xx - sx) ** 2 + (yy - sy) ** 2) / (2.0 * r ** 2)))
+    if target:
+        img += 180.0 * np.exp(-(((xx - size / 2) ** 2 + (yy - size / 2) ** 2) /
+                                (2.0 * 9.0 ** 2)))
+    img = np.clip(img, 0, 255).astype(np.uint8)
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+
+
+# ---------------------------------------------------------------------------
+# PIPP: sharpness + grading
+# ---------------------------------------------------------------------------
+def test_sharpness_orders_blur():
+    """Every metric must rank a crisp frame above a blurred copy."""
+    crisp = _textured(seed=1, blur=0.0)
+    soft = _textured(seed=1, blur=7.0)
+    for m in SHARPNESS_METHODS:
+        assert sharpness(crisp, m) > sharpness(soft, m), m
+    print("ok  sharpness orders crisp > blurred (all metrics)")
+
+
+def test_sharpness_roi():
+    """ROI scoring ignores pixels outside the box."""
+    img = _blob(center=(60, 60), radius=10)
+    # ROI on the blob vs ROI on empty sky -> blob region is sharper (more edges).
+    on = sharpness(img, "tenengrad", roi=(40, 40, 40, 40))
+    off = sharpness(img, "tenengrad", roi=(150, 150, 40, 40))
+    assert on > off
+    print("ok  sharpness ROI focuses on target")
+
+
+def test_grader_and_select():
+    frames = [
+        _textured(seed=2, blur=9.0),   # 0 worst
+        _textured(seed=2, blur=0.0),   # 1 best
+        _textured(seed=2, blur=3.0),   # 2 middle
+    ]
+    grades = QualityGrader("laplacian").grade(frames)
+    assert [g.index for g in grades] == [0, 1, 2]  # input order preserved
+    best = select_best(grades, fraction=0.5)
+    assert len(best) == 2 and best[0].index == 1   # sharpest first
+    one = select_best(grades, count=1)
+    assert len(one) == 1 and one[0].index == 1
+    # min_keep floors an over-aggressive fraction.
+    assert len(select_best(grades, fraction=0.0)) == 1
+    assert select_best([]) == []
+    print("ok  grader sorts + select_best culls (fraction/count/min_keep)")
+
+
+def test_grade_paths():
+    """Grader accepts file paths and dicts, not just arrays."""
+    with tempfile.TemporaryDirectory() as d:
+        p_sharp = os.path.join(d, "a.png")
+        p_soft = os.path.join(d, "b.png")
+        cv2.imwrite(p_sharp, _textured(seed=3, blur=0.0))
+        cv2.imwrite(p_soft, _textured(seed=3, blur=9.0))
+        grades = QualityGrader().grade([p_soft, {"path": p_sharp}])
+        best = select_best(grades, count=1)[0]
+        assert best.index == 1                       # the sharp one
+        assert best.source == {"path": p_sharp}
+    print("ok  grader handles paths + dict sources")
+
+
+# ---------------------------------------------------------------------------
+# PIPP: centring + cropping
+# ---------------------------------------------------------------------------
+def test_centroid_locks_target():
+    cx, cy = 132.0, 58.0
+    img = _blob(center=(cx, cy), radius=9, seed=5)
+    c = brightness_centroid(img)
+    assert c is not None
+    assert abs(c[0] - cx) < 2.0 and abs(c[1] - cy) < 2.0, c
+    # Empty sky -> no target.
+    flat = np.full((100, 100, 3), 20, np.uint8)
+    assert brightness_centroid(flat) is None
+    print(f"ok  brightness_centroid locks target ({c[0]:.1f},{c[1]:.1f})")
+
+
+def test_bounding_box():
+    img = _blob(center=(100, 100), radius=12, seed=6)
+    box = bounding_box(img, pad=2)
+    assert box is not None
+    x, y, w, h = box
+    assert x < 100 < x + w and y < 100 < y + h    # contains the centre
+    assert w < 120 and h < 120                     # and is a small box, not full frame
+    print(f"ok  bounding_box tight around target {box}")
+
+
+def test_crop_centered_size_and_padding():
+    img = _blob(center=(100, 100), radius=10, seed=7)
+    out = crop_centered(img, (100, 100), 50)
+    assert out.shape == (50, 50, 3)
+    # Centre of crop is bright (the blob), corners are sky.
+    assert int(out[25, 25].mean()) > int(out[0, 0].mean()) + 30
+    # Crop straddling a corner stays full-size, zero-padded outside the image.
+    edge = crop_centered(img, (2, 2), 40, pad_value=0)
+    assert edge.shape == (40, 40, 3)
+    assert edge[0, 0].sum() == 0                   # off-frame corner padded
+    print("ok  crop_centered fixed-size + edge padding")
+
+
+def test_recenter_moves_target_to_middle():
+    img = _blob(center=(150, 40), radius=10, seed=8)
+    out = recenter_frame(img)
+    c = brightness_centroid(out)
+    h, w = out.shape[:2]
+    assert abs(c[0] - w / 2) < 3 and abs(c[1] - h / 2) < 3, c
+    print("ok  recenter_frame centres the target")
+
+
+# ---------------------------------------------------------------------------
+# AutoStakkert: alignment points
+# ---------------------------------------------------------------------------
+def test_alignment_grid_shape():
+    grid = AlignmentPointGrid.over((400, 600), spacing=100)
+    assert grid.rows >= 2 and grid.cols >= 2
+    assert len(grid) == grid.rows * grid.cols
+    # points lie inside the frame
+    assert grid.points[:, 0].max() <= 600 and grid.points[:, 1].max() <= 400
+    print(f"ok  alignment grid {grid.rows}x{grid.cols} = {len(grid)} pts")
+
+
+def test_warp_by_grid_constant_field_is_translation():
+    """A uniform shift field must reproduce a plain integer translation."""
+    img = _textured(size=120, seed=9)
+    grid = AlignmentPointGrid.over(img.shape, spacing=40)
+    shift = np.zeros((len(grid), 2))
+    shift[:, 0] = 5.0   # sample 5px to the right everywhere -> content moves left
+    out = warp_by_grid(img, grid, shift)
+    ref = np.roll(img, -5, axis=1)
+    inner = slice(10, -10)
+    diff = np.abs(out[inner, inner].astype(int) - ref[inner, inner].astype(int)).mean()
+    assert diff < 3.0, diff
+    print("ok  warp_by_grid constant field == translation")
+
+
+def test_measure_local_shifts_recovers_translation():
+    """Phase-correlation shift sign is consistent with warp_by_grid's convention."""
+    ref = _textured(size=160, seed=11)
+    dx, dy = 4, -3
+    moved = np.roll(np.roll(ref, dx, axis=1), dy, axis=0)  # content shifted by (dx,dy)
+    grid = AlignmentPointGrid.over(ref.shape, spacing=50)
+    shifts = measure_local_shifts(ref, moved, grid.points, patch=64)
+    med = np.median(shifts, axis=0)
+    # Re-warping 'moved' by the measured field should land back on 'ref'.
+    fixed = warp_by_grid(moved, grid, shifts)
+    inner = slice(20, -20)
+    before = np.abs(moved[inner, inner].astype(int) - ref[inner, inner].astype(int)).mean()
+    after = np.abs(fixed[inner, inner].astype(int) - ref[inner, inner].astype(int)).mean()
+    assert after < before * 0.4, (before, after, med)
+    print(f"ok  local shifts recover translation (err {before:.1f} -> {after:.1f})")
+
+
+# ---------------------------------------------------------------------------
+# AutoStakkert: the stacker
+# ---------------------------------------------------------------------------
+def _jittered_noisy_set(n=24, size=160, noise=30, seed=0):
+    """A static starfield captured n times with random sub-pixel jitter + noise."""
+    rng = np.random.default_rng(seed)
+    truth = _starfield(size=size, seed=seed)
+    frames = []
+    for i in range(n):
+        jx, jy = rng.normal(0, 3, 2)
+        M = np.float32([[1, 0, jx], [0, 1, jy]])
+        shifted = cv2.warpAffine(truth, M, (size, size), borderMode=cv2.BORDER_REFLECT)
+        noisy = np.clip(shifted.astype(np.float64) +
+                        rng.normal(0, noise, shifted.shape), 0, 255).astype(np.uint8)
+        frames.append(noisy)
+    return truth, frames
+
+
+def test_stacker_improves_snr():
+    """Averaging aligned frames must beat a single frame's noise."""
+    truth, frames = _jittered_noisy_set(n=24, noise=30, seed=21)
+    stacker = LuckyStacker(method="orb")
+    # Use a clean reference (jitter=0) so we measure against ground truth.
+    stacker.set_reference(truth)
+    for f in frames:
+        stacker.add(f)
+    master = stacker.result()
+    assert master is not None
+
+    # Compare noise (std of the flat sky corner) and error vs truth.
+    def corner_std(im):
+        return float(im[:30, :30].astype(np.float64).std())
+    single_err = np.abs(frames[0].astype(int) - truth.astype(int)).mean()
+    stack_err = np.abs(master.astype(int) - truth.astype(int)).mean()
+    assert stack_err < single_err * 0.6, (single_err, stack_err)
+    assert corner_std(master) < corner_std(frames[0]) * 0.7
+    st = stacker.stats
+    assert st.n_stacked >= int(0.7 * (len(frames) + 1)), st
+    print(f"ok  stacker SNR: err {single_err:.1f} -> {stack_err:.1f}, "
+          f"stacked {st.n_stacked}/{st.n_total + 1}")
+
+
+def test_stacker_local_runs_and_stacks():
+    """Local (alignment-point) stacking produces a valid master and improves SNR."""
+    truth, frames = _jittered_noisy_set(n=18, noise=28, seed=22)
+    stacker = LuckyStacker(method="orb", local=True, ap_spacing=50, ap_patch=48)
+    stacker.set_reference(truth)
+    for f in frames:
+        stacker.add(f)
+    master = stacker.result()
+    assert master is not None and master.shape == truth.shape
+    stack_err = np.abs(master.astype(int) - truth.astype(int)).mean()
+    single_err = np.abs(frames[0].astype(int) - truth.astype(int)).mean()
+    assert stack_err < single_err * 0.7, (single_err, stack_err)
+    print(f"ok  local stacker master err {single_err:.1f} -> {stack_err:.1f}")
+
+
+def test_stacker_rejects_unalignable():
+    """A frame that can't be aligned is dropped, not smeared into the master."""
+    truth, frames = _jittered_noisy_set(n=6, noise=20, seed=23)
+    stacker = LuckyStacker(method="orb")
+    stacker.set_reference(truth)
+    for f in frames:
+        stacker.add(f)
+    good = stacker.stats.n_stacked
+    # Pure noise shares no features with the reference -> rejected.
+    junk = (np.random.default_rng(99).random(truth.shape) * 255).astype(np.uint8)
+    stacker.add(junk)
+    assert stacker.stats.n_stacked == good       # not added
+    assert stacker.stats.n_rejected >= 1
+    print(f"ok  stacker rejects unalignable frame ({stacker.stats.n_rejected} rejected)")
+
+
+def test_stacker_empty_result_is_none():
+    s = LuckyStacker()
+    assert s.result() is None
+    assert s.stack([]) is None
+    print("ok  empty stacker -> None")
+
+
+# ---------------------------------------------------------------------------
+# Run-level glue
+# ---------------------------------------------------------------------------
+class _FakeRun:
+    """Minimal Run stand-in: writes frames to disk and indexes them like Run."""
+
+    def __init__(self, frames, times, directory):
+        self._frames = []
+        for i, (arr, t) in enumerate(zip(frames, times)):
+            p = os.path.join(directory, f"Camera1_{i:06d}.bmp")
+            cv2.imwrite(p, cv2.cvtColor(arr, cv2.COLOR_RGB2BGR))
+            self._frames.append({"path": p, "t": float(t), "seq": i})
+
+    def frames(self, cam_index):
+        return self._frames
+
+
+def test_stack_run_pipeline():
+    truth, frames = _jittered_noisy_set(n=20, noise=30, seed=24)
+    # Make a few frames much blurrier so culling has something to drop.
+    for i in (0, 5, 11):
+        frames[i] = cv2.GaussianBlur(frames[i], (9, 9), 6)
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        seen = []
+        res = stack_run(run, 0, keep_fraction=0.5, quality="laplacian",
+                        progress=lambda done, total: seen.append((done, total)))
+        assert res.master is not None
+        assert res.stats.n_stacked >= 1
+        # Sharpest frame anchors the stack, and the blurred ones are culled.
+        kept_idx = {g.index for g in res.kept}
+        assert res.reference_index == res.kept[0].index
+        assert 0 not in kept_idx and 5 not in kept_idx   # blurred frames dropped
+        assert len(res.kept) == round(0.5 * len(frames))
+        assert seen and seen[-1][0] == seen[-1][1]       # progress reached 100%
+
+        out = os.path.join(d, "master.png")
+        save_master(res.master, out)
+        assert os.path.exists(out)
+        loaded = _decode(out)
+        assert loaded is not None and loaded.shape == res.master.shape
+    print(f"ok  stack_run pipeline (kept {len(res.kept)}, "
+          f"stacked {res.stats.n_stacked}, ref #{res.reference_index})")
+
+
+def test_stack_run_keep_count_and_window():
+    truth, frames = _jittered_noisy_set(n=12, noise=20, seed=25)
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        # keep_count overrides fraction.
+        res = stack_run(run, 0, keep_count=3)
+        assert len(res.kept) == 3
+        # time window restricts the candidate set; FrameGrade.source carries the
+        # original frame dict so callers can map a grade back to its capture.
+        res2 = stack_run(run, 0, keep_fraction=1.0, t_start=2, t_end=5)
+        assert all(2 <= g.source["t"] <= 5 for g in res2.grades)
+        assert len(res2.grades) == 4
+    print("ok  stack_run keep_count + time window")
+
+
+def test_stack_run_max_frames_subsample():
+    truth, frames = _jittered_noisy_set(n=30, noise=15, seed=26)
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        res = stack_run(run, 0, keep_fraction=1.0, max_frames=10)
+        assert len(res.grades) <= 10 and res.master is not None
+    print("ok  stack_run max_frames subsampling")
+
+
+def test_stack_exporter_thread():
+    """The threaded StackExporter writes a master PNG and reports stats."""
+    import time
+    from post_process import StackExporter
+
+    truth, frames = _jittered_noisy_set(n=16, noise=25, seed=27)
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        out = os.path.join(d, "master.png")
+        exp = StackExporter(run, 0, t_start=None, t_end=None, out_path=out,
+                            keep_fraction=0.5, local=False)
+        exp.start()
+        for _ in range(400):
+            if exp.done:
+                break
+            time.sleep(0.02)
+        assert exp.done and exp.error is None, exp.error
+        assert os.path.exists(exp.out_path) and os.path.getsize(exp.out_path) > 0
+        assert exp.stats is not None and exp.stats.n_stacked >= 1
+        assert abs(exp.progress - 1.0) < 1e-6
+    print(f"ok  StackExporter thread (stacked {exp.stats.n_stacked})")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            import traceback
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+            traceback.print_exc()
+    print("-" * 40)
+    print("ALL PASSED" if failed == 0 else f"{failed} test(s) failed")
+    raise SystemExit(1 if failed else 0)

--- a/test_stacking.py
+++ b/test_stacking.py
@@ -169,6 +169,18 @@ def test_crop_centered_size_and_padding():
     print("ok  crop_centered fixed-size + edge padding")
 
 
+def test_crop_centered_odd_size_is_centered():
+    """The target must land on the centre pixel (out//2) for even AND odd sizes."""
+    img = np.zeros((60, 60, 3), np.uint8)
+    img[33, 21] = 255                                # single bright px at (x=21,y=33)
+    for size in (40, 41):                            # even and odd
+        out = crop_centered(img, (21, 33), size)
+        g = cv2.cvtColor(out, cv2.COLOR_RGB2GRAY)
+        peak_y, peak_x = np.unravel_index(int(g.argmax()), g.shape)
+        assert (peak_x, peak_y) == (size // 2, size // 2), (size, peak_x, peak_y)
+    print("ok  crop_centered centres even + odd sizes on out//2")
+
+
 def test_recenter_moves_target_to_middle():
     img = _blob(center=(150, 40), radius=10, seed=8)
     out = recenter_frame(img)
@@ -185,9 +197,15 @@ def test_alignment_grid_shape():
     grid = AlignmentPointGrid.over((400, 600), spacing=100)
     assert grid.rows >= 2 and grid.cols >= 2
     assert len(grid) == grid.rows * grid.cols
-    # points lie inside the frame
-    assert grid.points[:, 0].max() <= 600 and grid.points[:, 1].max() <= 400
-    print(f"ok  alignment grid {grid.rows}x{grid.cols} = {len(grid)} pts")
+    # Nodes span the full frame edge-to-edge (so cv2.resize lands each shift on
+    # the pixel it was measured at), not an inset sub-region.
+    assert grid.points[:, 0].min() == 0 and grid.points[:, 1].min() == 0
+    assert grid.points[:, 0].max() == 599 and grid.points[:, 1].max() == 399
+    # A tiny frame still yields a non-degenerate >=2x2 grid (no collapsed axis).
+    tiny = AlignmentPointGrid.over((3, 3), spacing=80)
+    assert tiny.rows >= 2 and tiny.cols >= 2
+    assert tiny.points[:, 0].min() != tiny.points[:, 0].max()
+    print(f"ok  alignment grid {grid.rows}x{grid.cols} = {len(grid)} pts, spans edges")
 
 
 def test_warp_by_grid_constant_field_is_translation():
@@ -206,15 +224,16 @@ def test_warp_by_grid_constant_field_is_translation():
 
 def test_measure_local_shifts_recovers_translation():
     """Phase-correlation shift sign is consistent with warp_by_grid's convention."""
-    ref = _textured(size=160, seed=11)
+    ref = _textured(size=200, seed=11)
     dx, dy = 4, -3
-    moved = np.roll(np.roll(ref, dx, axis=1), dy, axis=0)  # content shifted by (dx,dy)
+    M = np.float32([[1, 0, dx], [0, 1, dy]])         # warp (not roll) -> no wrap
+    moved = cv2.warpAffine(ref, M, (200, 200), borderMode=cv2.BORDER_REFLECT)
     grid = AlignmentPointGrid.over(ref.shape, spacing=50)
     shifts = measure_local_shifts(ref, moved, grid.points, patch=64)
     med = np.median(shifts, axis=0)
     # Re-warping 'moved' by the measured field should land back on 'ref'.
     fixed = warp_by_grid(moved, grid, shifts)
-    inner = slice(20, -20)
+    inner = slice(30, -30)
     before = np.abs(moved[inner, inner].astype(int) - ref[inner, inner].astype(int)).mean()
     after = np.abs(fixed[inner, inner].astype(int) - ref[inner, inner].astype(int)).mean()
     assert after < before * 0.4, (before, after, med)
@@ -258,9 +277,12 @@ def test_stacker_improves_snr():
     assert stack_err < single_err * 0.6, (single_err, stack_err)
     assert corner_std(master) < corner_std(frames[0]) * 0.7
     st = stacker.stats
-    assert st.n_stacked >= int(0.7 * (len(frames) + 1)), st
+    # Reference + all added frames are accounted for, and the counts reconcile.
+    assert st.n_total == len(frames) + 1, st
+    assert st.n_stacked + st.n_rejected == st.n_total, st
+    assert st.n_stacked >= int(0.7 * st.n_total), st
     print(f"ok  stacker SNR: err {single_err:.1f} -> {stack_err:.1f}, "
-          f"stacked {st.n_stacked}/{st.n_total + 1}")
+          f"stacked {st.n_stacked}/{st.n_total}")
 
 
 def test_stacker_local_runs_and_stacks():
@@ -292,6 +314,37 @@ def test_stacker_rejects_unalignable():
     assert stacker.stats.n_stacked == good       # not added
     assert stacker.stats.n_rejected >= 1
     print(f"ok  stacker rejects unalignable frame ({stacker.stats.n_rejected} rejected)")
+
+
+def test_stacker_no_border_vignette():
+    """Coverage weighting must keep shifted black borders out of the master.
+
+    Every frame is translated by a large, same-direction shift, so a naive
+    sum/count average would darken one whole border band. Per-pixel coverage
+    weighting (the reference covers everything) must keep edges near the truth.
+    """
+    truth = _starfield(size=160, seed=40)
+    shift = 16
+    frames = []
+    for i in range(8):
+        M = np.float32([[1, 0, shift], [0, 1, shift]])
+        frames.append(cv2.warpAffine(truth, M, (160, 160),
+                                     borderMode=cv2.BORDER_CONSTANT, borderValue=0))
+    stacker = LuckyStacker(method="orb")
+    stacker.set_reference(truth)
+    for f in frames:
+        stacker.add(f)
+    master = stacker.result()
+    assert master is not None
+    # The top-left band is where every shifted frame contributed black; with
+    # coverage weighting it should still track the reference, not collapse to 0.
+    band_master = master[:shift, :shift].astype(np.float64).mean()
+    band_truth = truth[:shift, :shift].astype(np.float64).mean()
+    assert abs(band_master - band_truth) < 12.0, (band_master, band_truth)
+    # And no all-black pixels anywhere (a naive average would zero the corner).
+    assert master.sum(axis=2).min() > 0
+    print(f"ok  stacker coverage avoids border vignette "
+          f"(band {band_master:.0f} vs truth {band_truth:.0f})")
 
 
 def test_stacker_empty_result_is_none():

--- a/test_stacking.py
+++ b/test_stacking.py
@@ -18,6 +18,7 @@ import cv2
 
 from stacking import (
     sharpness, SHARPNESS_METHODS, QualityGrader, FrameGrade, select_best,
+    content_score, prefilter_garbage,
     brightness_centroid, bounding_box, crop_centered, recenter_frame,
     AlignmentPointGrid, measure_local_shifts, warp_by_grid,
     LuckyStacker, stack_run, save_master, _decode,
@@ -87,6 +88,61 @@ def test_sharpness_orders_blur():
     for m in SHARPNESS_METHODS:
         assert sharpness(crisp, m) > sharpness(soft, m), m
     print("ok  sharpness orders crisp > blurred (all metrics)")
+
+
+def test_sharpness_scale_preserves_order():
+    """Reduced-resolution grading still ranks crisp above blurred (for speed)."""
+    crisp = _textured(seed=4, blur=0.0)
+    soft = _textured(seed=4, blur=7.0)
+    assert sharpness(crisp, scale=0.5) > sharpness(soft, scale=0.5)
+    assert sharpness(crisp, scale=0.25) > sharpness(soft, scale=0.25)
+    print("ok  sharpness ranking preserved at reduced scale")
+
+
+def test_sharpness_is_fooled_by_noise_but_content_is_not():
+    """The core reason the pre-cull exists: sharpness rewards noise.
+
+    A pure-noise frame scores HIGHER on sharpness than a faint but real target,
+    so a naive top-X% cull would keep junk and drop good data. content_score
+    must invert that ordering.
+    """
+    faint = _blob(size=200, center=(100, 100), radius=22, amp=45, bg=12, blur=2.0, seed=1)
+    noise = cv2.cvtColor((np.random.default_rng(2).normal(30, 26, (200, 200))
+                          ).clip(0, 255).astype(np.uint8), cv2.COLOR_GRAY2RGB)
+    assert sharpness(noise) > sharpness(faint)              # the trap
+    assert content_score(faint) > content_score(noise)      # the fix
+    print(f"ok  sharpness fooled by noise, content_score not "
+          f"(sharp n>{sharpness(noise):.0f}>f{sharpness(faint):.0f}; "
+          f"content f>{content_score(faint):.1f}>n{content_score(noise):.1f})")
+
+
+def test_content_score_separates_signal():
+    real = _starfield(size=200, seed=3)
+    faint = _blob(size=200, center=(100, 100), radius=20, amp=50, bg=12, blur=2.0, seed=3)
+    noise = cv2.cvtColor((np.random.default_rng(4).normal(30, 25, (200, 200))
+                          ).clip(0, 255).astype(np.uint8), cv2.COLOR_GRAY2RGB)
+    blank = np.full((200, 200, 3), 15, np.uint8)
+    assert content_score(real) > content_score(faint) > content_score(noise)
+    assert content_score(noise) > content_score(blank) - 1e-6  # blank ~ 0
+    assert content_score(blank) < 1.0
+    print("ok  content_score orders real > faint > noise > blank")
+
+
+def test_prefilter_drops_only_garbage():
+    """Pre-cull removes noise/blank but keeps every real frame (incl. faint)."""
+    frames = [_starfield(size=200, seed=s) for s in range(6)]         # 0..5 real
+    frames.append(_blob(size=200, center=(100, 100), radius=20,       # 6 faint real
+                        amp=48, bg=12, blur=2.0, seed=9))
+    frames.append(cv2.cvtColor((np.random.default_rng(7).normal(30, 26, (200, 200))
+                                ).clip(0, 255).astype(np.uint8), cv2.COLOR_GRAY2RGB))  # 7 noise
+    frames.append(np.full((200, 200, 3), 15, np.uint8))              # 8 blank
+    grades = QualityGrader(with_content=True).grade(frames)
+    survivors, dropped = prefilter_garbage(grades)
+    kept_idx = {g.index for g in survivors}
+    drop_idx = {g.index for g in dropped}
+    assert drop_idx == {7, 8}, (drop_idx, kept_idx)          # only noise + blank
+    assert {0, 1, 2, 3, 4, 5, 6} <= kept_idx                 # all real survive
+    print(f"ok  prefilter drops garbage {sorted(drop_idx)}, keeps real+faint")
 
 
 def test_sharpness_roi():
@@ -243,10 +299,25 @@ def test_measure_local_shifts_recovers_translation():
 # ---------------------------------------------------------------------------
 # AutoStakkert: the stacker
 # ---------------------------------------------------------------------------
-def _jittered_noisy_set(n=24, size=160, noise=30, seed=0):
-    """A static starfield captured n times with random sub-pixel jitter + noise."""
+def _texture_scene(size=200, seed=0):
+    """A fixed extended-texture target (like a resolved planet/lunar surface).
+
+    Unlike a point-source starfield, this has stable features at every scale, so
+    it survives downscaling -- the case where half-res alignment is appropriate.
+    """
     rng = np.random.default_rng(seed)
-    truth = _starfield(size=size, seed=seed)
+    img = cv2.GaussianBlur((rng.random((size, size)) * 255).astype(np.uint8), (3, 3), 0)
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+
+
+def _jittered_noisy_set(n=24, size=160, noise=30, seed=0, base=None):
+    """A static scene captured n times with random sub-pixel jitter + noise.
+
+    Defaults to a starfield; pass ``base`` (e.g. :func:`_texture_scene`) for an
+    extended-texture target.
+    """
+    rng = np.random.default_rng(seed)
+    truth = _starfield(size=size, seed=seed) if base is None else base
     frames = []
     for i in range(n):
         jx, jy = rng.normal(0, 3, 2)
@@ -354,6 +425,50 @@ def test_stacker_empty_result_is_none():
     print("ok  empty stacker -> None")
 
 
+def test_seed_stack_and_merge_counts_reference_once():
+    """Map-reduce: only the seeding worker holds the reference; merge joins sums."""
+    truth = _starfield(size=160, seed=50)
+    frames = [truth.copy() for _ in range(5)]        # identity -> all align cleanly
+    a = LuckyStacker(method="orb"); a.set_reference(truth, seed_stack=True)
+    b = LuckyStacker(method="orb"); b.set_reference(truth, seed_stack=False)
+    for f in frames[:3]:
+        a.add(f)
+    for f in frames[3:]:
+        b.add(f)
+    a.merge(b)
+    # Reference counted exactly once: 1 (ref) + 5 identical adds = 6.
+    assert a.stats.n_stacked == 6, a.stats
+    assert a.stats.n_total == a.stats.n_stacked + a.stats.n_rejected
+    assert int(a._weight.max()) == 6                 # peak coverage == frames summed
+    master = a.result()
+    assert np.abs(master.astype(int) - truth.astype(int)).mean() < 1.0
+    print("ok  seed_stack=False + merge counts reference once")
+
+
+def test_align_scale_half_still_improves_snr():
+    """Estimating the transform at half-res still aligns + denoises the stack.
+
+    Uses an extended-texture target (resolved planet/lunar-like), which is where
+    half-res alignment applies -- point-source star fields blur away when
+    downscaled. This is the speed/quality trade the align_scale knob exposes; it
+    must still stack most frames and cut noise.
+    """
+    base = _texture_scene(size=240, seed=51)
+    truth, frames = _jittered_noisy_set(n=18, size=240, noise=22, seed=51, base=base)
+    stk = LuckyStacker(method="orb", align_scale=0.5)
+    stk.set_reference(truth)
+    for f in frames:
+        stk.add(f)
+    master = stk.result()
+    assert master is not None
+    single = np.abs(frames[0].astype(int) - truth.astype(int)).mean()
+    stack_err = np.abs(master.astype(int) - truth.astype(int)).mean()
+    assert stack_err < single * 0.7, (single, stack_err)
+    assert stk.stats.n_stacked >= int(0.6 * stk.stats.n_total), stk.stats
+    print(f"ok  align_scale=0.5 improves SNR ({single:.1f} -> {stack_err:.1f}, "
+          f"stacked {stk.stats.n_stacked}/{stk.stats.n_total})")
+
+
 # ---------------------------------------------------------------------------
 # Run-level glue
 # ---------------------------------------------------------------------------
@@ -412,6 +527,34 @@ def test_stack_run_keep_count_and_window():
         assert all(2 <= g.source["t"] <= 5 for g in res2.grades)
         assert len(res2.grades) == 4
     print("ok  stack_run keep_count + time window")
+
+
+def test_stack_run_parallel_matches_serial():
+    """workers>1 (map-reduce) yields the same stacked set and ~same master."""
+    truth, frames = _jittered_noisy_set(n=16, size=200, noise=18, seed=52)
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        r1 = stack_run(run, 0, keep_fraction=1.0, workers=1, prefilter=False)
+        r4 = stack_run(run, 0, keep_fraction=1.0, workers=4, prefilter=False)
+        assert r1.stats == r4.stats, (r1.stats, r4.stats)
+        diff = np.abs(r1.master.astype(int) - r4.master.astype(int)).mean()
+        assert diff < 2.0, diff
+    print(f"ok  parallel stack matches serial (stats {r4.stats}, master diff {diff:.2f})")
+
+
+def test_stack_run_prefilter_drops_garbage_end_to_end():
+    """Injected noise/blank frames are pre-culled before ranking + stacking."""
+    truth, frames = _jittered_noisy_set(n=14, size=200, noise=18, seed=53)
+    frames.append(cv2.cvtColor((np.random.default_rng(1).normal(30, 26, (200, 200))
+                                ).clip(0, 255).astype(np.uint8), cv2.COLOR_GRAY2RGB))
+    frames.append(np.full((200, 200, 3), 15, np.uint8))
+    with tempfile.TemporaryDirectory() as d:
+        run = _FakeRun(frames, times=range(len(frames)), directory=d)
+        res = stack_run(run, 0, keep_fraction=1.0, prefilter=True)
+        dropped_idx = {g.index for g in res.dropped}
+        assert {14, 15} <= dropped_idx, dropped_idx     # noise + blank removed
+        assert res.master is not None
+    print(f"ok  stack_run pre-culls garbage end-to-end (dropped {sorted(dropped_idx)})")
 
 
 def test_stack_run_max_frames_subsample():


### PR DESCRIPTION
## Summary

Extends the post-processing capability toward the PIPP → AutoStakkert workflow used for planetary / lunar / satellite imaging. The mental model the project already follows: **PIPP tidies and aligns, AutoStakkert stacks, then a wavelet tool sharpens.** This PR adds the first two stages as a headless, unit-tested core plus replay-UI wiring.

## What's new

**`stacking.py`** — pure numpy/OpenCV, headless and testable:

*PIPP stage (prep & conditioning)*
- `sharpness()` — per-frame sharpness via `laplacian` (default), `tenengrad`, or `fft`, with optional ROI.
- `QualityGrader` + `select_best()` — grade frames worst→best and cull to the sharpest top X% (or top N) — i.e. "lucky" frame selection.
- `brightness_centroid()` / `bounding_box()` — find a bright target on dark sky.
- `crop_centered()` / `recenter_frame()` — re-centre the target on the canvas and/or crop a small box around it (the big win for a fast mover like the ISS).

*AutoStakkert stage (stacking)*
- `AlignmentPointGrid` + `measure_local_shifts()` — a regular grid of alignment points and each point's sub-pixel shift vs a reference (local distortion from seeing), via phase correlation.
- `warp_by_grid()` — remap a frame by the dense field interpolated from the AP shifts.
- `LuckyStacker` — align the selected frames to a reference (RANSAC similarity via the existing `Stabilizer`), optionally apply AP local warping, and average them into one high-SNR master. Frames that fail to align are dropped, not smeared.
- `stack_run()` — runs the whole PIPP→AutoStakkert flow over an on-disk `Run`.

**Wiring**
- `StackExporter` in `post_process.py` — threaded stack export (mirrors `Mp4Exporter`'s `start`/`progress`/`done`/`error` contract), writes a linear master PNG (intentionally no gamma/brightness/contrast baked in, since the master is the input to a later sharpening step).
- `post_process_ui.py` — export panel buttons: **Stack best 25%**, **Stack best 50%**, and **Stack 50% (align points)**, stacking the marked In→Out range.

## Testing

`test_stacking.py` — 19 self-contained tests (synthetic starfields/blobs, no real capture data or UI required):
- sharpness orders crisp > blurred for every metric; ROI focusing
- grading/sorting + `select_best` fraction/count/min_keep; path & dict sources
- centroid/bbox/crop fixed-size + edge padding/recenter
- alignment-point grid shape, constant-field == translation, local-shift translation recovery
- global + local stacking SNR improvement vs a single frame; rejection of unalignable frames
- `stack_run` pipeline (culling, reference selection, progress, save/reload), keep_count/time-window/max_frames
- threaded `StackExporter`

All 19 pass (direct run and under pytest); stable across repeated runs. Existing `test_stabilizer.py` still passes.

## Notes
- Requires `opencv-python`/`numpy` (already used across the project).
- README's post-processing bullet updated to describe the new pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSf1XzV4g3chSVQzghfBr1)_