### PR TITLE
Fix Rust-loop watchdog false-tripping with a stale skytracker_core wheel

### DIFF
--- a/doc/BENCH_CHECKLIST.md
+++ b/doc/BENCH_CHECKLIST.md
@@ -15,6 +15,12 @@ everything, including an in-flight Park**.
 ## 0. Prep (at the desk, before hardware)
 
 - [ ] `pytest` green locally; CI green on the branch you're about to run.
+- [ ] **If using the Rust loop: rebuild the wheel after every pull** —
+      `maturin build --release -m rust/skytracker_core/Cargo.toml && pip
+      install --force-reinstall rust/skytracker_core/target/wheels/skytracker_core-*.whl`.
+      A stale wheel runs but silently lacks new APIs (a pre-2026-07 wheel has
+      no liveness counter; the adapter now detects this and tells you to
+      rebuild instead of misreading it as a stalled loop).
 - [ ] Config sanity: site lat/lon/alt set (without them, per-frame trajectory
       CSV rows fall back to az=0 — they *are* written now, but with degraded
       azimuth); safety limits set to the mount frame values you actually mean

--- a/rust_loop_adapter.py
+++ b/rust_loop_adapter.py
@@ -52,8 +52,10 @@ class RustCoreLoopAdapter:
 
     # Loop-liveness watchdog: if the Rust loop's cycle_count stops advancing
     # for this long (or the loop reports itself dead), stop the mount from
-    # Python and latch the fault until the telescope is reconnected.
+    # Python, tear the loop down, and retry after WATCHDOG_RETRY_SEC (or
+    # immediately on a telescope reconnect).
     WATCHDOG_STALL_SEC = 2.0
+    WATCHDOG_RETRY_SEC = 5.0
 
     def __init__(self, joystick_mode_state, config_state, target_hz=15):
         self.state = joystick_mode_state
@@ -64,7 +66,8 @@ class RustCoreLoopAdapter:
         self._thread = None
         self._last_cycle_count = -1
         self._last_cycle_advance = time.monotonic()
-        self._loop_fault_latched = False
+        self._loop_retry_at = 0.0        # monotonic time before which we don't rebuild
+        self._warned_no_liveness = False
         self._last_pushed_frame_seq = None
         self._park_state = None
 
@@ -107,10 +110,11 @@ class RustCoreLoopAdapter:
         st = self.state
         connected = bool(st.telescope_connected) and st.telescope_controller is not None
         if not connected:
-            # Reconnecting is the operator's explicit reset of a latched
-            # loop fault (see _watchdog).
-            self._loop_fault_latched = False
-        if self.loop is None and connected and not self._loop_fault_latched:
+            # Reconnecting is the operator's explicit "retry now" for a
+            # watchdog-tripped loop (see _watchdog).
+            self._loop_retry_at = 0.0
+        if (self.loop is None and connected
+                and time.monotonic() >= self._loop_retry_at):
             self.loop = rc.CoreLoop.wrap_mount(st.telescope_controller, self.target_hz)
             self._last_cycle_count = -1
             self._last_cycle_advance = time.monotonic()
@@ -127,13 +131,38 @@ class RustCoreLoopAdapter:
         'loop_dead' when its thread exits (including a contained panic). A
         snapshot whose count stops advancing is stale no matter what 'fresh'
         says, so: stop the mount from Python (the controller lock serializes
-        this with any remaining loop traffic), tear the loop down, and latch
-        the fault until the operator reconnects the telescope.
+        this with any remaining loop traffic), tear the loop down, and retry
+        after WATCHDOG_RETRY_SEC (a reconnect retries immediately). Snapshots
+        without a cycle_count (an old wheel) disable stall detection instead
+        of tripping it.
 
         Returns True when the loop was torn down (pump must not keep using it).
         """
         now = time.monotonic()
-        count = snap.get("cycle_count", -1)
+        if "cycle_count" not in snap:
+            # An installed skytracker_core wheel that predates the liveness
+            # API never reports cycle_count. That is NOT a stall: without
+            # this guard the "never advancing" count tripped the watchdog
+            # exactly WATCHDOG_STALL_SEC after every connect (the loop
+            # tracked for ~2 s, was torn down, and stayed dead until a
+            # reconnect). Disable stall detection and tell the operator to
+            # rebuild once.
+            if not self._warned_no_liveness:
+                self._warned_no_liveness = True
+                msg = ("RustCoreLoopAdapter: installed skytracker_core wheel "
+                       "predates the liveness API - loop-stall watchdog "
+                       "disabled. Rebuild it: maturin build --release -m "
+                       "rust/skytracker_core/Cargo.toml && pip install "
+                       "--force-reinstall rust/skytracker_core/target/wheels/"
+                       "skytracker_core-*.whl")
+                print(msg)
+                if self.state.update_status_callback:
+                    self.state.update_status_callback(
+                        "Rust loop: OLD skytracker_core wheel - rebuild it "
+                        "(see console); stall watchdog disabled")
+            return False
+
+        count = snap["cycle_count"]
         if count != self._last_cycle_count:
             self._last_cycle_count = count
             self._last_cycle_advance = now
@@ -144,7 +173,8 @@ class RustCoreLoopAdapter:
 
         reason = "loop thread died" if dead else (
             f"loop stalled >{self.WATCHDOG_STALL_SEC:.0f}s")
-        msg = f"RustCoreLoopAdapter: {reason} - stopping mount, reverting to fault-latched state"
+        msg = (f"RustCoreLoopAdapter: {reason} - stopping mount; retrying in "
+               f"{self.WATCHDOG_RETRY_SEC:.0f}s (reconnect telescope to retry now)")
         print(msg)
         st = self.state
         if st.update_status_callback:
@@ -163,7 +193,7 @@ class RustCoreLoopAdapter:
             pass
         self.loop = None
         st.position_fresh = False
-        self._loop_fault_latched = True
+        self._loop_retry_at = now + self.WATCHDOG_RETRY_SEC
         return True
 
     def _pump(self):

--- a/test_rust_loop_adapter.py
+++ b/test_rust_loop_adapter.py
@@ -198,5 +198,84 @@ class AdapterTests(unittest.TestCase):
         self.assertIsNone(adapter.loop)
 
 
+@unittest.skipUnless(_HAVE_CORE, "skytracker_core not built (run `maturin develop`)")
+class WatchdogTests(unittest.TestCase):
+    """Liveness-watchdog behavior, including the old-wheel regression: a
+    skytracker_core build without cycle_count in snapshots must DISABLE the
+    stall watchdog, not trip it 2 s after every connect (which presented as
+    'the sim mount tracks briefly after reconnect, then stops')."""
+
+    def _adapter(self, mode=None):
+        from joystick_controller import TrackingMode
+        from rust_loop_adapter import RustCoreLoopAdapter
+        ctrl = FakeMount()
+        st = fake_state(ctrl, mode or TrackingMode.STANDBY)
+        msgs = []
+        st.update_status_callback = msgs.append
+        adapter = RustCoreLoopAdapter(st, fake_config(), target_hz=50)
+        return adapter, st, ctrl, msgs
+
+    def test_missing_cycle_count_does_not_trip_watchdog(self):
+        adapter, st, ctrl, msgs = self._adapter()
+        self.assertTrue(adapter._ensure_loop())
+        loop = adapter.loop
+        # Simulate an old-wheel snapshot: no cycle_count / loop_dead keys, and
+        # let far more than WATCHDOG_STALL_SEC of apparent silence accumulate.
+        adapter._last_cycle_advance -= 10 * adapter.WATCHDOG_STALL_SEC
+        old_snap = {"fresh": True, "azm": 0.0, "alt": 0.0}
+        for _ in range(5):
+            self.assertFalse(adapter._watchdog(old_snap),
+                             "missing liveness API must not read as a stall")
+        self.assertIs(adapter.loop, loop, "loop must not be torn down")
+        self.assertTrue(any("wheel" in m for m in msgs),
+                        f"operator should be told to rebuild: {msgs}")
+        adapter.loop.stop()
+        adapter.loop = None
+
+    def test_real_stall_trips_then_retries_after_cooldown(self):
+        adapter, st, ctrl, msgs = self._adapter()
+        self.assertTrue(adapter._ensure_loop())
+        # A snapshot whose cycle_count stops advancing IS a stall.
+        adapter._last_cycle_count = 42
+        adapter._last_cycle_advance = time.monotonic() - (adapter.WATCHDOG_STALL_SEC + 1)
+        tripped = adapter._watchdog({"cycle_count": 42, "loop_dead": False})
+        self.assertTrue(tripped)
+        self.assertIsNone(adapter.loop)
+        self.assertTrue(any("retrying" in m for m in msgs), msgs)
+        # Within the cooldown: no rebuild.
+        self.assertFalse(adapter._ensure_loop())
+        # After the cooldown: rebuilds on its own (no reconnect needed).
+        adapter._loop_retry_at = time.monotonic() - 0.01
+        self.assertTrue(adapter._ensure_loop())
+        adapter.loop.stop()
+        adapter.loop = None
+
+    def test_reconnect_clears_retry_cooldown_immediately(self):
+        adapter, st, ctrl, msgs = self._adapter()
+        adapter._loop_retry_at = time.monotonic() + 1000.0
+        st.telescope_connected = False
+        self.assertFalse(adapter._ensure_loop())   # disconnect resets cooldown
+        st.telescope_connected = True
+        self.assertTrue(adapter._ensure_loop(), "reconnect must retry immediately")
+        adapter.loop.stop()
+        adapter.loop = None
+
+    def test_live_loop_with_new_wheel_never_trips(self):
+        # End-to-end: real bridged loop running for > WATCHDOG_STALL_SEC with
+        # real snapshots must never trip the watchdog (cycle_count advances).
+        adapter, st, ctrl, msgs = self._adapter()
+        self.assertTrue(adapter._ensure_loop())
+        deadline = time.time() + 2.5 * adapter.WATCHDOG_STALL_SEC
+        while time.time() < deadline:
+            snap = adapter.loop.snapshot()
+            self.assertIn("cycle_count", snap,
+                          "wheel in this env must expose the liveness API")
+            self.assertFalse(adapter._watchdog(snap),
+                             "healthy loop must not trip the watchdog")
+            time.sleep(0.1)
+        adapter.loop.stop()
+        adapter.loop = None
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes the field-reported regression from PR #13: with `use_rust_core_loop` on, the sim mount stopped responding ~2 s after every connect ("RustCoreLoopAdapter: loop stalled >2s … fault-latched state" repeating in the console); disconnect/reconnect bought another 2 s.

## Root cause

The new liveness watchdog reads `snapshot['cycle_count']` — a key that only exists in `skytracker_core` wheels **rebuilt from the reviewed sources**. Against an older installed wheel the key is always absent, so the watchdog's "count" never advanced and it declared a perfectly healthy loop stalled exactly `WATCHDOG_STALL_SEC` (2 s) after every (re)connect, then latched it dead until reconnect.

## Fixes

- A snapshot **without** `cycle_count` now disables stall detection and prints a one-time rebuild instruction, instead of misreading the missing API as a stall.
- The trip response is a **5 s retry cooldown** instead of a hard latch-until-reconnect — a transient stall recovers on its own, and the message says exactly what happens next.
- New `WatchdogTests` (4 tests): old-wheel snapshots never trip; a real stall trips → cools down → rebuilds; reconnect clears the cooldown immediately; a live bridged loop running well past the stall window never trips.
- `BENCH_CHECKLIST.md` prep step: rebuild the wheel after every pull when running the Rust loop.

## Immediate workaround (no code needed)

Rebuilding the wheel also makes the merged code work as intended:

```
maturin build --release -m rust/skytracker_core/Cargo.toml
pip install --force-reinstall rust/skytracker_core/target/wheels/skytracker_core-*.whl
```

## Test evidence

Full suite: 298 passed + 202 subtests, 2 skipped — including the 7-test adapter suite with the new watchdog cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj)_