### PR TITLE
Shortest spherical path: choose between the mount's two axis solutions (west→east flip bug)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -6,6 +6,37 @@ Newest entries first.
 
 ---
 
+## 2026-07-07 — Per-axis shortest-arc wrap is not shortest spherical path
+
+Field report from the sim: mount pointed west, target in the east — PROGRAM
+tracking drove the azimuth axis ~180° the long way around instead of ~90° of
+ALT motion straight over the zenith.
+
+The per-axis modular wrap (the earlier "360 lap" / ALT-seam fixes) reduces
+each axis error to ±180°, but it only ever sees the **canonical** mount
+solution. An alt-az style mount reaches every sky pointing in **two** axis
+configurations — canonical, and over-the-zenith via the mirrored sky
+representation `(az+180°, 180−el)` (in the AltAz convention that is
+`(AZM+180°, −ALT)`). When the target is on the far side of the sky, the
+flipped solution is often far shorter, and no amount of per-axis wrapping
+can discover it.
+
+Fix: `control.choose_mount_target` evaluates both solutions each cycle
+(minimax wrapped axis error, 0.5° hysteresis so near-ties don't flap
+mid-slew, safety-limit aware — an out-of-limits solution is never chosen),
+mirrored in the Rust `step_program`. Two knock-on sign rules matter: the
+ALT **feed-forward sign inverts** in the flipped configuration (the axis
+runs opposite), and the limit gate must gate the solution actually being
+driven to. Fixing the FF sign here also resolved a long-standing divergence
+where the launch path had no AltAz negation at all.
+
+General principle: on a two-axis mount, "shortest path" is a choice between
+*configurations* first and per-axis arcs second. Any future mode (Eq
+meridian flips, HANDOFF) that computes axis errors from a sky target needs
+to ask "which of the mount's solutions am I wrapping toward?"
+
+---
+
 ## 2026-07-03 — Stacking performance + the "sharpness rewards noise" trap
 
 Profiling the stacking pipeline ([`stacking.py`](stacking.py)) on realistic

--- a/control.py
+++ b/control.py
@@ -379,6 +379,91 @@ def sky_target_to_mount(config_state, target_az_deg, target_el_deg):
     return target_azm_deg, target_alt_deg
 
 
+# Prefer the flipped mount solution only when it is decisively shorter, so a
+# near-tie (target ~90 deg away in both configurations) can't flap between
+# solutions from cycle to cycle mid-slew.
+FLIP_HYSTERESIS_DEG = 0.5
+
+
+def mount_target_for(config_state, target_az_deg, target_el_deg, flipped):
+    """Mount-axis coordinates of a sky target in a CHOSEN configuration.
+
+    ``flipped=False`` is the canonical solution (sky_target_to_mount).
+    ``flipped=True`` pushes the mirrored sky representation
+    ``(az+180, 180-el)`` -- the same physical pointing -- through the same
+    transform, yielding the 'over the zenith' axis solution (for the AltAz
+    convention that is (AZM+180, -ALT)).
+    """
+    if not flipped:
+        return sky_target_to_mount(config_state, target_az_deg, target_el_deg)
+    return sky_target_to_mount(config_state,
+                               (target_az_deg + 180.0) % 360.0,
+                               180.0 - target_el_deg)
+
+
+def choose_mount_target(config_state, current_azm_deg, current_alt_deg,
+                        target_az_deg, target_el_deg, limits=None):
+    """Pick the mount-axis solution with the shortest slew to a sky target.
+
+    An alt-az style mount reaches every sky pointing in TWO axis
+    configurations: the canonical one, and the over-the-zenith one from the
+    mirrored sky representation (az+180, 180-el). The per-axis shortest-arc
+    wrap (the earlier '360 lap' fix) cannot discover the second solution:
+    pointed west with the target in the east, the canonical solution demands
+    a ~180-deg azimuth slew the long way around, while the flipped solution
+    is a ~90-deg ALT move straight over the zenith. Choose per cycle by
+    minimax wrapped axis error, with FLIP_HYSTERESIS_DEG of preference for
+    the canonical solution so near-ties don't oscillate.
+
+    Only AltAz and Passthrough modes have a usable second solution here; in
+    Eq mode the mirrored representation maps to the same axis coordinates
+    (a true meridian flip changes pier side and pointing-model terms, so it
+    is deliberately not attempted by the tracking loop).
+
+    ``limits``: optional (azm_min, azm_max, alt_min, alt_max) mount-frame
+    safety limits; a solution outside them is never chosen. If no solution
+    is inside, the canonical one is returned so the caller's safety gate
+    aborts exactly as it would have before.
+
+    Note: with the pointing model enabled, its correction in the flipped
+    configuration is an extrapolation of a fit made in the canonical one --
+    fine for choosing the path, but expect to re-center after a flip.
+
+    Returns (target_azm_deg, target_alt_deg, flipped).
+    """
+    mount_mode = getattr(config_state, 'mount_mode', 'AltAz')
+    canon = mount_target_for(config_state, target_az_deg, target_el_deg, False)
+    candidates = [(canon, False)]
+    if mount_mode in ('AltAz', 'Passthrough'):
+        candidates.append(
+            (mount_target_for(config_state, target_az_deg, target_el_deg, True), True))
+
+    def _wrap(d):
+        return (d + 180.0) % 360.0 - 180.0
+
+    def metric(t):
+        # Axes slew simultaneously, so slew time ~ the larger axis error.
+        return max(abs(_wrap(t[0] - current_azm_deg)),
+                   abs(_wrap(t[1] - current_alt_deg)))
+
+    def in_limits(t):
+        if limits is None:
+            return True
+        azm_min, azm_max, alt_min, alt_max = limits
+        return (azm_min <= t[0] <= azm_max) and (alt_min <= t[1] <= alt_max)
+
+    legal = [(t, f) for t, f in candidates if in_limits(t)]
+    if not legal:
+        return canon[0], canon[1], False
+    (best_t, best_f) = legal[0]
+    best_m = metric(best_t)
+    for t, f in legal[1:]:
+        m = metric(t)
+        if m < best_m - FLIP_HYSTERESIS_DEG:
+            best_t, best_f, best_m = t, f, m
+    return best_t[0], best_t[1], best_f
+
+
 def compute_mount_position_error(config_state, current_azm_deg, current_alt_deg, target_az_deg, target_el_deg):
     """
     Compute position error between current mount position and target position.
@@ -397,8 +482,11 @@ def compute_mount_position_error(config_state, current_azm_deg, current_alt_deg,
     Returns:
         tuple: (az_error_deg, el_error_deg) - errors in degrees
     """
-    target_azm_deg, target_alt_deg = sky_target_to_mount(
-        config_state, target_az_deg, target_el_deg)
+    # Shortest-slew solution: canonical, or over-the-zenith when that is
+    # decisively shorter (see choose_mount_target).
+    target_azm_deg, target_alt_deg, _flipped = choose_mount_target(
+        config_state, current_azm_deg, current_alt_deg,
+        target_az_deg, target_el_deg)
 
     # Compute error in mount coordinates
     azm_error_deg = target_azm_deg - current_azm_deg

--- a/joystick_controller.py
+++ b/joystick_controller.py
@@ -31,7 +31,8 @@ from camera_manager import apply_gamma_correction, roi_sizes, roi_label_texts
 from utils import draw_button
 
 # Import PID controller and helper functions
-from control import create_pid_controllers, compute_mount_position_error, sky_target_to_mount
+from control import (create_pid_controllers, compute_mount_position_error,
+                     sky_target_to_mount, choose_mount_target, mount_target_for)
 from trajectory import interpolate_position_data_and_rates
 from hotspot import detect_hotspot, pixel_offset_to_angles
 
@@ -964,8 +965,16 @@ class JoystickModeState:
                     # target through the command transform before comparing --
                     # in AltAz mode mount ALT = 90 - el, so gating raw sky el
                     # against a mount limit is checking the wrong quantity.
-                    target_azm_mount, target_alt_mount = sky_target_to_mount(
-                        self.config_state, target_az_deg, target_el_deg)
+                    # choose_mount_target additionally picks the SHORTEST-slew
+                    # axis solution (canonical, or over-the-zenith when the
+                    # target is on the far side of the sky) among solutions
+                    # inside the limits -- pointed west with the target in the
+                    # east, the loop must go up through the zenith, not drive
+                    # the azimuth axis 180 deg the long way around.
+                    target_azm_mount, target_alt_mount, target_flipped = choose_mount_target(
+                        self.config_state, current_azm, current_alt,
+                        target_az_deg, target_el_deg,
+                        limits=(azm_limit_min, azm_limit_max, alt_limit_min, alt_limit_max))
                     if (target_azm_mount > azm_limit_max or target_azm_mount < azm_limit_min or
                         target_alt_mount > alt_limit_max or target_alt_mount < alt_limit_min):
                         self.tracking_mode = TrackingMode.STANDBY
@@ -996,21 +1005,29 @@ class JoystickModeState:
                     target_az_deg, target_el_deg = self._apply_bias_to_target(
                         target_az_deg, target_el_deg, az_rate, el_rate)
 
-                    # Compute position errors using config state instance
-                    az_error, el_error = compute_mount_position_error(
-                        self.config_state, current_azm, current_alt, target_az_deg, target_el_deg
-                    )
+                    # Position errors in mount coordinates, in the SAME axis
+                    # configuration the gate chose above (recomputing the choice
+                    # after lead/bias could disagree at the decision boundary).
+                    target_azm_mount, target_alt_mount = mount_target_for(
+                        self.config_state, target_az_deg, target_el_deg, target_flipped)
+                    az_error = (target_azm_mount - current_azm + 180.0) % 360.0 - 180.0
+                    el_error = (target_alt_mount - current_alt + 180.0) % 360.0 - 180.0
 
                     # Set feed-forward rates from trajectory. The trajectory gives
                     # sky rates; the PID drives the mount. AZM tracks azimuth
-                    # directly, but in AltAz the ALT axis runs opposite sky
-                    # elevation (ALT = 90 - el), so the ALT feed-forward is -el_rate.
-                    # Without this the elevation feed-forward pushes the wrong way.
+                    # directly, but the ALT axis direction depends on the mount
+                    # convention AND the chosen configuration: in AltAz the ALT
+                    # axis runs opposite sky elevation (ALT = 90 - el), and the
+                    # over-the-zenith (flipped) solution runs opposite the
+                    # canonical one. Without the right sign the elevation
+                    # feed-forward pushes the wrong way.
                     if self.feed_forward_azm_enabled:
                         self.azm_pid.set_feed_forward_rate(az_rate)
                     if self.feed_forward_alt_enabled:
-                        alt_ff_rate = -el_rate if getattr(self.config_state, 'mount_mode', 'Eq') == 'AltAz' else el_rate
-                        self.alt_pid.set_feed_forward_rate(alt_ff_rate)
+                        alt_sign = -1.0 if getattr(self.config_state, 'mount_mode', 'Eq') == 'AltAz' else 1.0
+                        if target_flipped:
+                            alt_sign = -alt_sign
+                        self.alt_pid.set_feed_forward_rate(alt_sign * el_rate)
 
                     # Update PID controllers
                     current_time = time.time()
@@ -1161,9 +1178,11 @@ class JoystickModeState:
 
             # Launch is above horizon - use PID control for tracking
             # Check hardware safety limits against target position first, in the
-            # MOUNT frame (see program_track: the limits gate encoder positions).
-            target_azm_mount, target_alt_mount = sky_target_to_mount(
-                self.config_state, az_deg, target_el_deg)
+            # MOUNT frame; choose_mount_target also picks the shortest-slew axis
+            # solution (see program_track: canonical vs over-the-zenith).
+            target_azm_mount, target_alt_mount, target_flipped = choose_mount_target(
+                self.config_state, current_azm, current_alt, az_deg, target_el_deg,
+                limits=(azm_limit_min, azm_limit_max, alt_limit_min, alt_limit_max))
             if (target_azm_mount > azm_limit_max or target_azm_mount < azm_limit_min or
                 target_alt_mount > alt_limit_max or target_alt_mount < alt_limit_min):
                 self.tracking_mode = TrackingMode.STANDBY
@@ -1189,16 +1208,24 @@ class JoystickModeState:
             az_deg, target_el_deg = self._apply_bias_to_target(
                 az_deg, target_el_deg, az_rate_dps, el_rate_dps)
 
-            # Compute position errors using config state instance
-            az_error, el_error = compute_mount_position_error(
-                self.config_state, current_azm, current_alt, az_deg, target_el_deg
-            )
+            # Position errors in mount coordinates, in the SAME configuration
+            # the gate chose (see program_track).
+            target_azm_mount, target_alt_mount = mount_target_for(
+                self.config_state, az_deg, target_el_deg, target_flipped)
+            az_error = (target_azm_mount - current_azm + 180.0) % 360.0 - 180.0
+            el_error = (target_alt_mount - current_alt + 180.0) % 360.0 - 180.0
 
-            # Set feed-forward rates from launch trajectory
+            # Set feed-forward rates from launch trajectory. ALT sign follows
+            # the mount convention and the chosen configuration -- the same
+            # rule as program_track (this path used to omit the AltAz
+            # negation, a long-standing divergence between the two).
             if self.feed_forward_azm_enabled:
                 self.azm_pid.set_feed_forward_rate(az_rate_dps)
             if self.feed_forward_alt_enabled:
-                self.alt_pid.set_feed_forward_rate(el_rate_dps)
+                alt_sign = -1.0 if getattr(self.config_state, 'mount_mode', 'Eq') == 'AltAz' else 1.0
+                if target_flipped:
+                    alt_sign = -alt_sign
+                self.alt_pid.set_feed_forward_rate(alt_sign * el_rate_dps)
 
             # Update PID controllers
             current_time = time.time()

--- a/rust/skytracker_core/src/controller.rs
+++ b/rust/skytracker_core/src/controller.rs
@@ -343,20 +343,62 @@ impl LoopState {
         let led_az = sp.az_deg + sp.ff_az_dps * lead;
         let led_el = sp.el_deg + sp.ff_el_dps * lead;
 
-        // Sky -> mount (the per-cycle transform we ported in step 5).
-        let (target_azm, target_alt) = transforms::sky_to_mount(
+        // Sky -> mount (the per-cycle transform we ported in step 5), choosing
+        // the SHORTEST-slew axis solution. An alt-az style mount reaches every
+        // sky pointing in two configurations: the canonical one and the
+        // over-the-zenith one from the mirrored sky representation
+        // (az+180, 180-el). Per-axis wrap alone cannot discover the second
+        // solution -- pointed west with the target in the east it drives the
+        // azimuth axis ~180 deg the long way instead of ~90 deg of ALT motion
+        // straight over the top. Mirrors control.choose_mount_target
+        // (same minimax metric, same hysteresis, limits-aware; Eq mode has no
+        // usable second solution here).
+        let canon = transforms::sky_to_mount(
             inputs.mount_mode,
             led_az,
             led_el,
             inputs.alignment_az,
             inputs.alignment_el,
         );
+        let (azm_min, azm_max) = inputs.azm_limit;
+        let (alt_min, alt_max) = inputs.alt_limit;
+        let in_limits = |t: (f64, f64)| {
+            t.0 >= azm_min && t.0 <= azm_max && t.1 >= alt_min && t.1 <= alt_max
+        };
+        let metric = |t: (f64, f64)| {
+            wrap180(t.0 - current_azm)
+                .abs()
+                .max(wrap180(t.1 - current_alt).abs())
+        };
+        const FLIP_HYSTERESIS_DEG: f64 = 0.5;
+        let mut target_azm = canon.0;
+        let mut target_alt = canon.1;
+        let mut flipped = false;
+        if inputs.mount_mode != MountMode::Eq {
+            let flip = transforms::sky_to_mount(
+                inputs.mount_mode,
+                (led_az + 180.0).rem_euclid(360.0),
+                180.0 - led_el,
+                inputs.alignment_az,
+                inputs.alignment_el,
+            );
+            let canon_ok = in_limits(canon);
+            let flip_ok = in_limits(flip);
+            let use_flip = match (canon_ok, flip_ok) {
+                (_, false) => false,
+                (false, true) => true,
+                (true, true) => metric(flip) < metric(canon) - FLIP_HYSTERESIS_DEG,
+            };
+            if use_flip {
+                target_azm = flip.0;
+                target_alt = flip.1;
+                flipped = true;
+            }
+        }
 
         // Safety: abort to STANDBY if the MOUNT-frame target exceeds the
         // configured axis limits (they gate encoder positions, so the check
         // must happen after sky_to_mount). Mirrors program_track.
-        let (azm_min, azm_max) = inputs.azm_limit;
-        let (alt_min, alt_max) = inputs.alt_limit;
         if target_azm > azm_max
             || target_azm < azm_min
             || target_alt > alt_max
@@ -386,14 +428,20 @@ impl LoopState {
             .update_gains(inputs.alt_gains.0, inputs.alt_gains.1, inputs.alt_gains.2);
         self.azm_pid.set_feed_forward_enabled(inputs.ff_azm_enabled);
         self.alt_pid.set_feed_forward_enabled(inputs.ff_alt_enabled);
-        // Sky rates -> mount feed-forward. AZM tracks azimuth directly; in AltAz
-        // the ALT axis runs opposite sky elevation (ALT = 90 - el), so the ALT
-        // feed-forward is -ff_el_dps. Mirrors joystick_controller.program_track.
-        let alt_ff = if inputs.mount_mode == MountMode::AltAz {
-            -sp.ff_el_dps
+        // Sky rates -> mount feed-forward. AZM tracks azimuth directly; the
+        // ALT direction follows the mount convention (in AltAz the axis runs
+        // opposite sky elevation, ALT = 90 - el) AND the chosen configuration
+        // (the over-the-zenith solution runs opposite the canonical one).
+        // Mirrors joystick_controller.program_track.
+        let mut alt_sign = if inputs.mount_mode == MountMode::AltAz {
+            -1.0
         } else {
-            sp.ff_el_dps
+            1.0
         };
+        if flipped {
+            alt_sign = -alt_sign;
+        }
+        let alt_ff = alt_sign * sp.ff_el_dps;
         self.azm_pid.set_feed_forward_rate(sp.ff_az_dps);
         self.alt_pid.set_feed_forward_rate(alt_ff);
 

--- a/rust/skytracker_core/tests/controller.rs
+++ b/rust/skytracker_core/tests/controller.rs
@@ -329,3 +329,67 @@ fn program_target_beyond_mount_limits_aborts_to_standby() {
     assert_eq!(o.requested_mode, None);
     assert!(o.azm_rate_cmd.is_some());
 }
+
+#[test]
+fn program_west_to_east_goes_over_the_zenith() {
+    // Mount west (270, 45), target east (az=90, el=45), Passthrough. The
+    // canonical solution is a 180-deg azimuth slew; the flipped one
+    // (az+180, 180-el) = (270, 135) is pure alt motion over the top. The
+    // loop must choose the flip: azm error ~0, alt error ~+90.
+    let mut s = LoopState::new();
+    let mut i = base_inputs();
+    i.mode = Mode::Program;
+    i.mount_mode = MountMode::Passthrough;
+    i.setpoint = Some(Setpoint {
+        az_deg: 90.0,
+        el_deg: 45.0,
+        ff_az_dps: 0.0,
+        ff_el_dps: 0.0,
+    });
+    let o = s.step(&i, None, 270.0, 45.0, 100.0);
+    assert!(o.azm_error.abs() < 1e-6, "azm must not slew the long way: {}", o.azm_error);
+    assert!((o.alt_error - 90.0).abs() < 1e-6, "alt error {}", o.alt_error);
+    assert!(o.alt_rate_cmd.unwrap_or(0) > 0, "ALT must drive up over the zenith");
+}
+
+#[test]
+fn program_flip_vetoed_by_alt_limits() {
+    // Same scenario but ALT limits exclude the flipped solution (alt 135):
+    // fall back to the legal canonical 180-deg azimuth path, not STANDBY.
+    let mut s = LoopState::new();
+    let mut i = base_inputs();
+    i.mode = Mode::Program;
+    i.mount_mode = MountMode::Passthrough;
+    i.alt_limit = (0.0, 90.0);
+    i.setpoint = Some(Setpoint {
+        az_deg: 90.0,
+        el_deg: 45.0,
+        ff_az_dps: 0.0,
+        ff_el_dps: 0.0,
+    });
+    let o = s.step(&i, None, 270.0, 45.0, 100.0);
+    assert_eq!(o.requested_mode, None, "canonical is legal - no abort");
+    assert!((o.azm_error.abs() - 180.0).abs() < 1e-6, "azm error {}", o.azm_error);
+    assert!(o.alt_error.abs() < 1e-6, "alt error {}", o.alt_error);
+}
+
+#[test]
+fn program_flip_altaz_error_convention() {
+    // AltAz convention (ALT = 90 - el): the flipped solution for the
+    // west-east scenario is (AZM=270, ALT=-45) -> alt error -90.
+    let mut s = LoopState::new();
+    let mut i = base_inputs();
+    i.mode = Mode::Program;
+    i.mount_mode = MountMode::AltAz;
+    i.setpoint = Some(Setpoint {
+        az_deg: 90.0,
+        el_deg: 45.0,
+        ff_az_dps: 0.0,
+        ff_el_dps: 0.0,
+    });
+    // current mount: AZM=270, ALT=45 (el=45, pointing west)
+    let o = s.step(&i, None, 270.0, 45.0, 100.0);
+    assert!(o.azm_error.abs() < 1e-6, "azm error {}", o.azm_error);
+    assert!((o.alt_error + 90.0).abs() < 1e-6, "alt error {}", o.alt_error);
+    assert!(o.alt_rate_cmd.unwrap_or(0) < 0);
+}

--- a/rust/skytracker_core/tests/core_loop.rs
+++ b/rust/skytracker_core/tests/core_loop.rs
@@ -195,3 +195,32 @@ fn consecutive_poll_faults_stop_motion() {
     );
     assert!(!fresh, "snapshot must be marked stale under comm faults");
 }
+
+#[test]
+fn west_to_east_converges_over_the_zenith_not_the_long_way() {
+    // Mount west (270, 45), target east (az=90, el=45), Passthrough: the
+    // closed loop must converge to the FLIPPED solution (270, 135) with the
+    // azimuth axis essentially parked -- not drag the azimuth 180 deg around.
+    let shared = Shared::new(program_inputs(90.0, 45.0));
+    let mut mount = Mount::new(LoopbackTransport::new(SimResponder::new_manual(270.0, 45.0)));
+    let mut state = LoopState::new();
+
+    let mut now = 0.0;
+    let mut az_excursion: f64 = 0.0;
+    for _ in 0..500 {
+        now += 0.1;
+        mount.io.responder.advance_time(0.1);
+        run_cycle(&mut mount, &mut state, &shared, now);
+        let az = mount.io.responder.az_true_deg;
+        let d = ((az - 270.0 + 180.0).rem_euclid(360.0) - 180.0).abs();
+        az_excursion = az_excursion.max(d);
+    }
+
+    let o = shared.outputs.lock().unwrap();
+    assert!((o.azm - 270.0).abs() < 2.0, "azm should stay ~270, got {}", o.azm);
+    assert!((o.alt - 135.0).abs() < 2.0, "alt should arrive at 135, got {}", o.alt);
+    assert!(
+        az_excursion < 10.0,
+        "azimuth slewed {az_excursion} deg -- it took the long way around"
+    );
+}

--- a/test_shortest_path_flip.py
+++ b/test_shortest_path_flip.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""
+Shortest-spherical-path regression tests (the west-to-east "long way around"
+bug).
+
+An alt-az style mount reaches every sky pointing in TWO axis configurations:
+canonical, and over-the-zenith (the mirrored sky representation
+(az+180, 180-el)). The per-axis shortest-arc wrap -- the earlier '360 lap'
+fix, still covered by test_wrap_shortest_path.py -- only ever considers the
+canonical solution, so with the mount pointed west and the target in the
+east the loop drove the azimuth axis ~180 deg the long way around instead of
+~90 deg of ALT motion straight over the zenith. choose_mount_target now
+picks between both solutions each cycle; these tests pin that choice, its
+limit awareness, its hysteresis, and the sign consequences all the way down
+to the commanded rates.
+
+Headless. Run: python test_shortest_path_flip.py
+"""
+
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import unittest
+
+import pygame
+pygame.init()
+
+from control import (FLIP_HYSTERESIS_DEG, choose_mount_target,
+                     compute_mount_position_error, mount_target_for)
+
+
+class _Cfg:
+    mount_mode = 'AltAz'
+    alignment_azimuth_str = '0.0'
+    alignment_elevation_str = '0.0'
+    pointing_model_enabled = False
+    eq_pointing_model_enabled = False
+    lat_str = '35.0'
+
+
+class _PassCfg(_Cfg):
+    mount_mode = 'Passthrough'
+
+
+class ChooseMountTargetTests(unittest.TestCase):
+
+    def test_west_to_east_goes_over_the_zenith(self):
+        # Mount west (AZM=270, ALT=45 i.e. el=45), target east (az=90, el=45).
+        # Canonical demands a 180-deg azimuth slew; the flipped solution is
+        # (AZM=270, ALT=-45): pure ALT motion through the zenith.
+        azm, alt, flipped = choose_mount_target(_Cfg(), 270.0, 45.0, 90.0, 45.0)
+        self.assertTrue(flipped)
+        self.assertAlmostEqual(azm, 270.0, places=6)
+        self.assertAlmostEqual(alt, -45.0, places=6)
+
+    def test_errors_take_the_zenith_path(self):
+        az_err, el_err = compute_mount_position_error(_Cfg(), 270.0, 45.0, 90.0, 45.0)
+        self.assertAlmostEqual(az_err, 0.0, places=6)
+        self.assertAlmostEqual(el_err, -90.0, places=6,
+                               msg="ALT should drive -90 deg through the zenith, "
+                                   "not spin azimuth 180 deg")
+
+    def test_nearby_target_stays_canonical(self):
+        azm, alt, flipped = choose_mount_target(_Cfg(), 270.0, 45.0, 280.0, 40.0)
+        self.assertFalse(flipped)
+        self.assertAlmostEqual(azm, 280.0, places=6)
+        self.assertAlmostEqual(alt, 50.0, places=6)
+
+    def test_passthrough_flip_convention(self):
+        # Passthrough: mount alt == sky el, so the flipped solution is
+        # (az+180, 180-el).
+        azm, alt, flipped = choose_mount_target(_PassCfg(), 270.0, 45.0, 90.0, 45.0)
+        self.assertTrue(flipped)
+        self.assertAlmostEqual(azm, 270.0, places=6)
+        self.assertAlmostEqual(alt, 135.0, places=6)
+
+    def test_limits_veto_the_flip(self):
+        # ALT limits [0, 90] exclude the flipped solution (ALT=-45): fall back
+        # to the (legal) canonical 180-deg azimuth path rather than aborting.
+        azm, alt, flipped = choose_mount_target(
+            _Cfg(), 270.0, 45.0, 90.0, 45.0, limits=(0.0, 360.0, 0.0, 90.0))
+        self.assertFalse(flipped)
+        self.assertAlmostEqual(azm, 90.0, places=6)
+        self.assertAlmostEqual(alt, 45.0, places=6)
+
+    def test_flip_chosen_when_only_it_is_legal(self):
+        # Canonical (ALT=45) outside limits, flipped (ALT=-45) inside.
+        azm, alt, flipped = choose_mount_target(
+            _Cfg(), 270.0, 45.0, 90.0, 45.0, limits=(0.0, 360.0, -90.0, 0.0))
+        self.assertTrue(flipped)
+        self.assertAlmostEqual(alt, -45.0, places=6)
+
+    def test_both_illegal_returns_canonical_for_the_gate(self):
+        azm, alt, flipped = choose_mount_target(
+            _Cfg(), 270.0, 45.0, 90.0, 45.0, limits=(0.0, 360.0, 50.0, 60.0))
+        self.assertFalse(flipped)
+        self.assertAlmostEqual(alt, 45.0, places=6)  # gate will abort on this
+
+    def test_hysteresis_prefers_canonical_on_near_ties(self):
+        # Canonical metric 90.3 vs flip metric 90.0: within the hysteresis
+        # band, so no flip (a flapping choice mid-slew is worse than 0.3 deg).
+        self.assertLess(0.3, FLIP_HYSTERESIS_DEG)
+        azm, alt, flipped = choose_mount_target(_Cfg(), 0.0, 45.0, 90.3, 45.0)
+        self.assertFalse(flipped)
+
+    def test_eq_mode_never_flips(self):
+        class EqCfg(_Cfg):
+            mount_mode = 'Eq'
+            alignment_elevation_str = '35.0'
+        azm, alt, flipped = choose_mount_target(EqCfg(), 270.0, 45.0, 90.0, 45.0)
+        self.assertFalse(flipped)
+
+    def test_mount_target_for_matches_choice(self):
+        # The gate chooses once; the error path re-derives the SAME solution
+        # from the flag (post lead/bias). The two must agree.
+        for cfg, cur in ((_Cfg(), (270.0, 45.0)), (_PassCfg(), (270.0, 45.0))):
+            azm, alt, flipped = choose_mount_target(cfg, cur[0], cur[1], 90.0, 45.0)
+            azm2, alt2 = mount_target_for(cfg, 90.0, 45.0, flipped)
+            self.assertAlmostEqual(azm, azm2, places=9)
+            self.assertAlmostEqual(alt, alt2, places=9)
+
+
+class ProgramTrackDirectionTests(unittest.TestCase):
+    """End-to-end: program_track pointed west with the target east must
+    command ALT motion (over the top), not a 180-deg azimuth slew."""
+
+    def test_commands_alt_not_azimuth(self):
+        import joystick_controller as jc
+        from joystick_controller import JoystickModeState, TrackingMode
+
+        class Cfg(_Cfg):
+            pid_azm_p_gain, pid_azm_i_gain, pid_azm_d_gain = 0.025, 0.0, 0.0
+            pid_alt_p_gain, pid_alt_i_gain, pid_alt_d_gain = 0.025, 0.0, 0.0
+            pid_lead_time_sec = 0.0
+            continuous_rate_tracking = False
+            azm_limit_min_str = "-100000"
+            azm_limit_max_str = "100000"
+            alt_limit_min_str = "-100000"
+            alt_limit_max_str = "100000"
+
+        class _RecController:
+            def __init__(self):
+                self.rates = {}
+
+            def hc_slew_fixed(self, target, rate):
+                self.rates[target] = rate
+                return True
+
+        class _Vis:
+            selected_launch = None
+            launch_launched = False
+            selected_aircraft = None
+            aircraft_trajectories = {}
+            current_tt = 0.0
+            selected_satellite = "EASTSAT"
+            satellite_trajectories = {"EASTSAT": ([(0,)] * 8, [0.0])}
+
+        state = JoystickModeState(None, Cfg(), lambda m: None)
+        state.telescope_connected = True
+        ctrl = _RecController()
+        state.telescope_controller = ctrl
+        state.tracking_vis_state = _Vis()
+        state.tracking_mode = TrackingMode.PROGRAM
+        state.current_azm = state.current_azm_raw = 270.0
+        state.current_alt = state.current_alt_raw = 45.0
+
+        orig = jc.interpolate_position_data_and_rates
+        jc.interpolate_position_data_and_rates = (
+            lambda traj, tt, *a, **k: (1.0, 1.0, 45.0, 500.0, 90.0, 0.0, 0.0))
+        try:
+            state.program_track()
+        finally:
+            jc.interpolate_position_data_and_rates = orig
+
+        self.assertAlmostEqual(state.azm_position_error, 0.0, places=6)
+        self.assertAlmostEqual(state.alt_position_error, -90.0, places=6)
+        self.assertEqual(ctrl.rates.get(jc.Targets.AZM, 0), 0,
+                         "azimuth must not slew the long way around")
+        self.assertLess(ctrl.rates.get(jc.Targets.ALT, 0), 0,
+                        "ALT must drive negative, over the zenith")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test_wrap_shortest_path.py
+++ b/test_wrap_shortest_path.py
@@ -68,7 +68,10 @@ class TestAzmShortestPath(unittest.TestCase):
         # Raw diff > 540 deg: the old one-shot if/elif wrap returned +190 (then
         # clamped to +180 -> long way). Shortest arc is -170.
         # current -200 (== 160), target 350 -> +190 raw -> -170 short.
-        az_err, _ = compute_mount_position_error(self.cfg, -200.0, 45.0, 350.0, 45.0)
+        # Geometry chosen (sky el 2, ALT near 88) so the over-the-zenith flip
+        # is LONGER than canonical and this stays a pure per-axis wrap test;
+        # the flip choice itself is covered by test_shortest_path_flip.py.
+        az_err, _ = compute_mount_position_error(self.cfg, -200.0, 88.0, 350.0, 2.0)
         self.assertAlmostEqual(az_err, -170.0, places=6)
 
 
@@ -104,8 +107,10 @@ class TestZeroErrorAtTarget(unittest.TestCase):
 
 
 class TestBothAxesAlwaysShortestArc(unittest.TestCase):
-    """Sweep: for any current position, the error must equal the true shortest
-    arc and never exceed 180 deg in magnitude -- on BOTH axes."""
+    """Sweep: for any current position, the error pair must be the per-axis
+    shortest arc to ONE of the two valid mount solutions (canonical or
+    over-the-zenith), it must never exceed 180 deg on either axis, and the
+    chosen solution must never be WORSE than canonical (minimax metric)."""
 
     def test_sweep_matches_modular_reference(self):
         for mode in ("AltAz", "Passthrough"):
@@ -117,18 +122,37 @@ class TestBothAxesAlwaysShortestArc(unittest.TestCase):
                             cfg, float(current), float(current),
                             float(target_sky_az), float(target_sky_el),
                         )
+                        # The two valid mount solutions for this pointing
+                        # (alignment 0/0): canonical, and the mirrored sky
+                        # representation (az+180, 180-el) through the same
+                        # transform.
                         if mode == "AltAz":
-                            target_azm = target_sky_az % 360.0
-                            target_alt = 90.0 - target_sky_el
+                            canon = (target_sky_az % 360.0, 90.0 - target_sky_el)
+                            flip = ((target_sky_az + 180.0) % 360.0,
+                                    90.0 - (180.0 - target_sky_el))
                         else:  # Passthrough: sky == mount
-                            target_azm = float(target_sky_az)
-                            target_alt = float(target_sky_el)
-                        self.assertAlmostEqual(
-                            az_err, shortest_arc(target_azm - current), places=6,
-                            msg=f"AZM {mode} current={current} target_az={target_sky_az}")
-                        self.assertAlmostEqual(
-                            alt_err, shortest_arc(target_alt - current), places=6,
-                            msg=f"ALT {mode} current={current} target_el={target_sky_el}")
+                            canon = (float(target_sky_az), float(target_sky_el))
+                            flip = ((target_sky_az + 180.0) % 360.0,
+                                    180.0 - target_sky_el)
+
+                        def errs(t):
+                            return (shortest_arc(t[0] - current),
+                                    shortest_arc(t[1] - current))
+
+                        e_canon, e_flip = errs(canon), errs(flip)
+                        got = (az_err, alt_err)
+                        matches = any(
+                            abs(got[0] - e[0]) < 1e-6 and abs(got[1] - e[1]) < 1e-6
+                            for e in (e_canon, e_flip))
+                        self.assertTrue(
+                            matches,
+                            msg=f"{mode} current={current} sky=({target_sky_az},"
+                                f"{target_sky_el}): {got} matches neither "
+                                f"{e_canon} nor {e_flip}")
+                        # Never worse than canonical, and both axes wrapped.
+                        metric = max(abs(got[0]), abs(got[1]))
+                        canon_metric = max(abs(e_canon[0]), abs(e_canon[1]))
+                        self.assertLessEqual(metric, canon_metric + 1e-9)
                         self.assertLessEqual(abs(az_err), 180.0 + 1e-9)
                         self.assertLessEqual(abs(alt_err), 180.0 + 1e-9)
 


### PR DESCRIPTION
## Summary

Fixes the field-reported quadrant/hemisphere bug: mount pointed west with the target in the east, PROGRAM tracking drove the azimuth axis ~180° the long way around instead of ~90° of ALT motion straight over the zenith.

## Why the old fix couldn't catch this

The per-axis shortest-arc wrap (the pre-existing "360 lap" / ALT-seam fixes — still in place and still tested) reduces each axis error to ±180°, but it only ever sees the **canonical** mount solution. An alt-az style mount reaches every sky pointing in **two** axis configurations: canonical, and over-the-zenith via the mirrored sky representation `(az+180°, 180−el)` (in the AltAz convention: `(AZM+180°, −ALT)`). When the target is on the far side of the sky, the flipped solution is far shorter — and no per-axis wrap can discover it. "Shortest path" is a choice between *configurations* first, per-axis arcs second.

## Changes

- **`control.choose_mount_target`**: evaluates both solutions each cycle by minimax wrapped axis error, with 0.5° hysteresis (near-ties must not flap mid-slew) and **safety-limit awareness** (an out-of-limits solution is never chosen; if the flip would exceed your ALT limits it falls back to the legal canonical path instead of aborting). Eq mode never flips (a true meridian flip changes pier side and pointing-model terms). `compute_mount_position_error` routes through it, so the mask-exit drive inherits the behavior.
- **`program_track` / `_program_track_launch`**: the limit gate chooses (limit-aware), the post-lead/bias error computation reuses the *same* chosen configuration, and the **ALT feed-forward sign inverts when flipped** (the axis runs opposite in that configuration). This also fixes the long-standing launch-path divergence that omitted the AltAz FF negation entirely.
- **Rust `step_program`**: identical choice (same metric, hysteresis, limit fallback) and FF sign handling — loop parity maintained.

## Tests

- `test_shortest_path_flip.py` (11): the west→east scenario at the choose/error/end-to-end levels (the last one runs the real `program_track` and asserts AZM rate 0, ALT rate driving over the top), limit veto + only-legal-flip + both-illegal cases, hysteresis, Passthrough convention, Eq never flips, gate/error configuration agreement.
- Rust: 3 step-level tests + a **closed-loop** `core_loop` test asserting the mount actually arrives at (270°, 135°) with < 10° of azimuth excursion — the direct "did it take the long way" regression check.
- `test_wrap_shortest_path.py` sweep updated: accepts either valid solution, asserts the choice is never worse than canonical, both axes always ≤ 180°.
- Full suite: **313 passed + 202 subtests** (includes the A/B loop parity harness, unchanged for nearby targets).

**Note:** the Rust wheel must be rebuilt after pulling (the flip lives in `controller.rs` too): `maturin build --release -m rust/skytracker_core/Cargo.toml && pip install --force-reinstall rust/skytracker_core/target/wheels/skytracker_core-*.whl` — the adapter will remind you if you forget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj)_