### PR TITLE
Fix HOTSPOT/HANDOFF stair-step walk-off + horizon-based trajectory refresh

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -6,6 +6,53 @@ Newest entries first.
 
 ---
 
+## 2026-07-07 — HOTSPOT/HANDOFF stair-steps: four coupled failure modes
+
+Field report: HANDOFF centered briefly then walked off in near-FOV-sized
+stair-steps; manual HOTSPOT reverted to PROGRAM immediately. A live-fidelity
+harness ([`test_mode_machine.py`](test_mode_machine.py)) — real
+`tracking_control()` state machine against the simulated mount, a paced
+camera thread, and the *tuned* `config.example.json` gains — reproduced the
+walk-off on the first run. Four distinct bugs compounded; any one of them
+alone would have been survivable:
+
+1. **Wrong elevation convention in the optical geometry.** The pixel↔angle
+   transforms need the SKY elevation for the cos(el) azimuth compression, but
+   `hotspot_track` passed the mount ALT axis (which is `90 − el` in AltAz).
+   At el=30° that overstates the azimuth error by cos(30)/cos(60) ≈ 1.73× —
+   a *divergent* per-step overshoot. This is the same convention trap as the
+   sky-vs-mount entry below: any code touching angles must say which frame
+   it's in.
+2. **Uncapped correction rates.** The PID output was clamped only by
+   `guide_rate_max_dps` (5°/s — a slew rate). One high-SNR detection at the
+   FOV edge commanded a lunge that swept the whole FOV before the next frame.
+   New `hotspot_max_rate_dps` (default 2.0) plus a measurement-cadence cap:
+   never cover more than ~90% of the remaining error per measured frame
+   interval — a centering loop must not outrun its own measurements.
+3. **Static tracking gate.** The search gate stayed where the target *was*;
+   the loop's own commanded slew streams the target across the frame, so a
+   legitimate correction pushed the target out of its own gate → instant
+   "lost". The gate is now predicted forward by the loop's own commanded
+   rates (anchored at the last detection, not the last frame) and grows
+   1.5×/miss (cap 4×) so residual error can't strand it.
+4. **Held rates never decayed on miss.** On a missed frame the mount kept
+   the last commanded rate indefinitely ("coast"), so one overshoot coasted
+   into the next stair-step. Held rates now halve per missed fresh frame —
+   coast through a one-frame dropout survives, sustained loss bleeds to zero.
+
+All four are mirrored in the Rust loop (`step_hotspot`), with
+`hotspot::angles_to_pixel_offset` added as the exact inverse of the forward
+transform for the gate prediction.
+
+General principle: closed-loop optical tracking bugs are invisible to
+open-loop unit tests — every piece (detector, PID, geometry) tested fine in
+isolation. The failures only appear when the loop's own actuation feeds back
+into its next measurement. Keep an end-to-end harness (real state machine +
+simulated physics + real config) as the regression net for any control-loop
+change.
+
+---
+
 ## 2026-07-07 — Per-axis shortest-arc wrap is not shortest spherical path
 
 Field report from the sim: mount pointed west, target in the east — PROGRAM

--- a/config.example.json
+++ b/config.example.json
@@ -67,6 +67,7 @@
   "hotspot_snr_threshold": 5.0,
   "hotspot_gate_radius": 120,
   "hotspot_coast_time_sec": 1.0,
+  "hotspot_max_rate_dps": 2.0,
   "handoff_min_frames": 5,
   "hotspot_x_sign": 1.0,
   "hotspot_y_sign": -1.0,

--- a/config.py
+++ b/config.py
@@ -115,6 +115,10 @@ class ConfigState:
         self.hotspot_snr_threshold = 5.0    # min (peak-bg)/noise to accept a detection
         self.hotspot_gate_radius = 120      # tracking-gate half-size in pixels once locked
         self.hotspot_coast_time_sec = 1.0   # coast this long on loss before falling back
+        # HOTSPOT is a CENTERING loop, not a slew: cap its commanded rate so a
+        # large pixel error can't lunge the mount and yank the target out of
+        # its own tracking gate (the acquire->yank->lose->fallback stair-step).
+        self.hotspot_max_rate_dps = 2.0
         self.hotspot_x_sign = 1.0           # per-axis sign calibration (set on hardware)
         self.hotspot_y_sign = -1.0
 
@@ -300,6 +304,7 @@ class ConfigState:
             "hotspot_camera_index": self.hotspot_camera_index,
             "hotspot_snr_threshold": self.hotspot_snr_threshold,
             "hotspot_gate_radius": self.hotspot_gate_radius,
+            "hotspot_max_rate_dps": self.hotspot_max_rate_dps,
             "hotspot_coast_time_sec": self.hotspot_coast_time_sec,
             "handoff_min_frames": self.handoff_min_frames,
             "hotspot_x_sign": self.hotspot_x_sign,
@@ -388,6 +393,7 @@ class ConfigState:
         self.hotspot_camera_index = config_dict.get("hotspot_camera_index", self.hotspot_camera_index)
         self.hotspot_snr_threshold = config_dict.get("hotspot_snr_threshold", self.hotspot_snr_threshold)
         self.hotspot_gate_radius = config_dict.get("hotspot_gate_radius", self.hotspot_gate_radius)
+        self.hotspot_max_rate_dps = config_dict.get("hotspot_max_rate_dps", self.hotspot_max_rate_dps)
         self.hotspot_coast_time_sec = config_dict.get("hotspot_coast_time_sec", self.hotspot_coast_time_sec)
         self.handoff_min_frames = config_dict.get("handoff_min_frames", self.handoff_min_frames)
         self.hotspot_x_sign = config_dict.get("hotspot_x_sign", self.hotspot_x_sign)

--- a/joystick_controller.py
+++ b/joystick_controller.py
@@ -306,6 +306,10 @@ class JoystickModeState:
         self.hotspot_centroid = None
         self.hotspot_status = ""
         self.hotspot_last_frame_seq = None   # last camera frame processed (stale gate)
+        self._hotspot_last_fresh_time = 0.0  # for the measured frame interval
+        self._hotspot_frame_interval = 0.2   # conservative until measured
+        self._hotspot_cmd_dps = (0.0, 0.0)   # last commanded rates (mount frame)
+        self._hotspot_gate_time = 0.0        # frame time the gate was anchored on
 
         # PID controllers for PROGRAM track mode
         self.azm_pid = None
@@ -1376,6 +1380,10 @@ class JoystickModeState:
         self.hotspot_centroid = None
         self.hotspot_snr = 0.0
         self.hotspot_last_frame_seq = None
+        self._hotspot_last_fresh_time = 0.0
+        self._hotspot_frame_interval = 0.2
+        self._hotspot_cmd_dps = (0.0, 0.0)
+        self._hotspot_gate_time = 0.0
         if self.azm_pid:
             self.azm_pid.reset()
         if self.alt_pid:
@@ -1445,10 +1453,59 @@ class JoystickModeState:
         except (ValueError, AttributeError):
             pass
 
+        now = time.time()
+
+        # Measured fresh-frame interval (hit OR miss): gate prediction and the
+        # correction-rate cap are sized to it, so the loop never outruns its
+        # own measurements.
+        elapsed_since_fresh = 0.0
+        if raw is not None:
+            if self._hotspot_last_fresh_time > 0.0:
+                elapsed_since_fresh = max(0.0, now - self._hotspot_last_fresh_time)
+                self._hotspot_frame_interval = max(0.05, min(2.0, elapsed_since_fresh))
+            self._hotspot_last_fresh_time = now
+
         detection = None
         if raw is not None:
             gate_center = self.hotspot_gate_center
-            gate_radius = int(getattr(cfg, 'hotspot_gate_radius', 120)) if gate_center else None
+            gate_radius = None
+            if gate_center:
+                # Predict where the target moved in the frame due to OUR OWN
+                # commanded slew since the last fresh frame (the boresight
+                # moved, so the target streams the other way in pixels). With
+                # a narrow FOV a legitimate correction sweeps a large pixel
+                # distance between frames; a static gate loses the target the
+                # loop is successfully converging on.
+                cam_name = f"camera{cam_index + 1}"
+                az_dps, alt_dps = getattr(self, '_hotspot_cmd_dps', (0.0, 0.0))
+                # Predict from the frame the gate was anchored on (the last
+                # detection) -- missed frames in between extend the span, and
+                # the commanded rate has been held constant since then.
+                gate_dt = max(0.0, now - getattr(self, '_hotspot_gate_time', now))
+                if gate_dt > 0.0 and (az_dps or alt_dps):
+                    el_sky_dps = (-alt_dps
+                                  if getattr(cfg, 'mount_mode', 'Eq') == 'AltAz'
+                                  else alt_dps)
+                    from simulator import angles_to_pixel
+                    el_sky_geom = (90.0 - current_alt
+                                   if getattr(cfg, 'mount_mode', 'Eq') == 'AltAz'
+                                   else current_alt)
+                    pdx, pdy = angles_to_pixel(
+                        -az_dps * gate_dt,
+                        -el_sky_dps * gate_dt,
+                        float(cfg.get_camera_pixel_size(cam_name)),
+                        float(cfg.get_camera_focal_length(cam_name)),
+                        float(cfg.get_camera_alignment_rotation(cam_name)),
+                        el_sky_geom,
+                        float(getattr(cfg, 'hotspot_x_sign', 1.0)),
+                        float(getattr(cfg, 'hotspot_y_sign', -1.0)))
+                    gate_center = (gate_center[0] + pdx, gate_center[1] + pdy)
+                # Grow the gate on consecutive misses (classic track-gate
+                # growth) so residual prediction error or target motion can't
+                # strand the gate while the target is still in frame.
+                base = int(getattr(cfg, 'hotspot_gate_radius', 120))
+                growth = min(4.0, 1.5 ** min(self.hotspot_miss_count, 8))
+                gate_radius = int(base * growth)
             try:
                 detection = detect_hotspot(
                     raw,
@@ -1460,8 +1517,6 @@ class JoystickModeState:
                 print(f"HOTSPOT: detection error: {e}")
                 detection = None
 
-        now = time.time()
-
         if detection is not None:
             # Pixel error of the object from boresight (image center).
             h, w = raw.shape[:2]
@@ -1469,12 +1524,20 @@ class JoystickModeState:
             dy = detection.cy - (h / 2.0)
 
             cam_name = f"camera{cam_index + 1}"
+            # The pixel->angle geometry needs the SKY elevation (azimuth
+            # compresses by cos(el) on the sky). In AltAz the mount ALT axis
+            # is 90-el: passing it raw overstates the azimuth error by
+            # cos(el)/cos(ALT) -- >1.5x at el=30 -- making every correction
+            # overshoot and the loop oscillate divergently.
+            el_sky = (90.0 - current_alt
+                      if getattr(cfg, 'mount_mode', 'Eq') == 'AltAz'
+                      else current_alt)
             az_error, el_error = pixel_offset_to_angles(
                 dx, dy,
                 pixel_size_um=float(cfg.get_camera_pixel_size(cam_name)),
                 focal_length_mm=float(cfg.get_camera_focal_length(cam_name)),
                 rotation_deg=float(cfg.get_camera_alignment_rotation(cam_name)),
-                el_deg=current_alt,
+                el_deg=el_sky,
                 x_sign=float(getattr(cfg, 'hotspot_x_sign', 1.0)),
                 y_sign=float(getattr(cfg, 'hotspot_y_sign', -1.0)),
             )
@@ -1498,6 +1561,7 @@ class JoystickModeState:
 
             # Update lock state and diagnostics.
             self.hotspot_gate_center = (detection.cx, detection.cy)
+            self._hotspot_gate_time = now
             self.hotspot_centroid = (detection.cx, detection.cy)
             self.hotspot_snr = detection.snr
             self.hotspot_acquired = True
@@ -1511,8 +1575,21 @@ class JoystickModeState:
 
             if self.telescope_connected and not self.stopped:
                 try:
-                    self._issue_axis_rate(Targets.AZM, az_pid_output, az_rate_cmd)
-                    self._issue_axis_rate(Targets.ALT, el_pid_output, el_rate_cmd)
+                    # Cap each axis so the correction covers at most ~90% of
+                    # the remaining error before the NEXT measurement arrives
+                    # (measured fresh-frame interval). Without this, a single
+                    # strong correction at a slow frame rate overshoots, exits
+                    # its own tracking gate, and then COASTS at full rate
+                    # through the loss window -- the FOV-sized stair-step.
+                    cap = float(getattr(cfg, 'hotspot_max_rate_dps', 2.0) or 2.0)
+                    interval = getattr(self, '_hotspot_frame_interval', 0.2)
+                    az_cap = min(cap, 0.9 * abs(az_error) / interval)
+                    el_cap = min(cap, 0.9 * abs(el_error) / interval)
+                    az_eff = self._issue_axis_rate(Targets.AZM, az_pid_output, az_rate_cmd, max_dps=az_cap)
+                    el_eff = self._issue_axis_rate(Targets.ALT, el_pid_output, el_rate_cmd, max_dps=el_cap)
+                    # Remember what we commanded (mount frame): gate prediction
+                    # uses it to move the search window with our own slew.
+                    self._hotspot_cmd_dps = (az_eff or 0.0, el_eff or 0.0)
                 except Exception as e:
                     print(f"HOTSPOT: error sending slew commands: {e}")
             return
@@ -1521,6 +1598,24 @@ class JoystickModeState:
         # miss -- only count misses against frames we actually examined.
         if not frame_is_stale:
             self.hotspot_miss_count += 1
+            # Bleed off the held correction: rates persist on the mount, and a
+            # correction that hasn't been confirmed by a detection must not
+            # keep integrating (that runaway is what turned a single overshoot
+            # into an FOV-sized stair-step). Halve per missed frame.
+            az_d, el_d = getattr(self, '_hotspot_cmd_dps', (0.0, 0.0))
+            if (abs(az_d) > 1e-3 or abs(el_d) > 1e-3) and self.telescope_connected and not self.stopped:
+                az_d *= 0.5
+                el_d *= 0.5
+                if abs(az_d) < 1e-3:
+                    az_d = 0.0
+                if abs(el_d) < 1e-3:
+                    el_d = 0.0
+                try:
+                    self._issue_axis_rate(Targets.AZM, az_d / 360.0, 0)
+                    self._issue_axis_rate(Targets.ALT, el_d / 360.0, 0)
+                    self._hotspot_cmd_dps = (az_d, el_d)
+                except Exception as e:
+                    print(f"HOTSPOT: error decaying rates: {e}")
         coast_time = float(getattr(cfg, 'hotspot_coast_time_sec', 1.0))
 
         if self.hotspot_acquired:
@@ -1546,7 +1641,7 @@ class JoystickModeState:
         if self.update_status_callback:
             self.update_status_callback("HOTSPOT: lost lock - falling back to PROGRAM track")
 
-    def _issue_axis_rate(self, target, pid_output_rev_s, discrete_cmd):
+    def _issue_axis_rate(self, target, pid_output_rev_s, discrete_cmd, max_dps=None):
         """Send one axis's rate to the mount.
 
         In continuous-rate mode use the fine 24-bit variable-rate (guide-rate)
@@ -1555,14 +1650,31 @@ class JoystickModeState:
         MC_MOVE step when the requested rate exceeds guide_rate_max_dps (the
         regime where the guide-rate command may not be honored, e.g. the
         near-zenith keyhole) or when continuous mode is off.
+
+        ``max_dps`` caps the commanded rate in BOTH paths. HOTSPOT passes its
+        hotspot_max_rate_dps: a centering loop that lunges at slew rates yanks
+        the target out of its own tracking gate before the next frame arrives
+        (the acquire -> yank -> lose -> fallback stair-step failure).
         """
         cfg = self.config_state
+        dps = pid_output_rev_s * 360.0
+        if max_dps is not None:
+            dps = max(-float(max_dps), min(float(max_dps), dps))
         if getattr(cfg, 'continuous_rate_tracking', False) and hasattr(self.telescope_controller, 'hc_set_rate_dps'):
-            dps = pid_output_rev_s * 360.0
             if abs(dps) <= float(getattr(cfg, 'guide_rate_max_dps', 5.0)):
                 self.telescope_controller.hc_set_rate_dps(target, dps)
-                return
+                return dps
+        if max_dps is not None and discrete_cmd != 0:
+            sign = 1 if discrete_cmd > 0 else -1
+            mag = abs(int(discrete_cmd))
+            # Largest discrete step whose rate fits under the cap (keep at
+            # least 1 so a capped axis still creeps toward center).
+            while mag > 1 and RATES.get(mag, 0.0) * 360.0 > float(max_dps):
+                mag -= 1
+            discrete_cmd = sign * mag
         self.telescope_controller.hc_slew_fixed(target, discrete_cmd)
+        sign = 1.0 if discrete_cmd >= 0 else -1.0
+        return sign * RATES.get(abs(int(discrete_cmd)), 0.0) * 360.0
 
     PARK_TIMEOUT_SEC = 90.0
     PARK_TOLERANCE_DEG = 1.0
@@ -1622,6 +1734,7 @@ class JoystickModeState:
 
     def _hotspot_stop_motion(self):
         """Best-effort stop of both axes."""
+        self._hotspot_cmd_dps = (0.0, 0.0)
         if self.telescope_connected and self.telescope_controller is not None:
             try:
                 self.telescope_controller.hc_slew_fixed(Targets.AZM, 0)

--- a/main.py
+++ b/main.py
@@ -48,7 +48,13 @@ from events import *
 
 # Update Intervals (seconds)
 POSITION_UPDATE_INTERVAL = 0.1  # 10 Hz
-TRAJECTORY_UPDATE_INTERVAL = 900  # 15 minutes
+# Trajectory auto-refresh policy: recompute when live time has consumed this
+# fraction of the FORWARD half of the trajectory window (the window is
+# centered on "now" at compute time, so only the forward half is future
+# coverage). A 2 h window therefore refreshes after ~45 min instead of on a
+# fixed short timer; the floor keeps a tiny window from thrashing the worker.
+TRAJECTORY_REFRESH_FRACTION = 0.75
+TRAJECTORY_REFRESH_MIN_SEC = 300.0
 
 # TLE API Configuration
 TLE_API_URL = 'https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=tle'
@@ -238,7 +244,6 @@ last_trajectory_update = -1
 last_update_time = 0
 update_interval = 1.0 / 30.0  # Target 30 Hz (vectorized update is ~0.6 ms, so cheap)
 last_trajectory_update = -1  # Force immediate trigger on first loop
-trajectory_interval = 900  # 15 minutes
 
 # ==============================================================================
 # MAIN PROGRAM LOOP
@@ -333,10 +338,22 @@ while running:
             update_status_callback(f"Error recomputing: {str(e)}")
             tracking_vis_state.recompute_triggered = False
 
-    # Precompute trajectories and arc segments every 15 minutes (background).
-    if (current_time - last_trajectory_update >= trajectory_interval
+    # Precompute trajectories and arc segments in the background, refreshing
+    # when the live time has consumed most of the forward half of the window
+    # (see TRAJECTORY_REFRESH_FRACTION) -- NOT on a fixed short timer, which
+    # recomputed a 2-hour window every 15 minutes for no reason.
+    try:
+        duration_minutes_auto = float(tracking_vis_state.duration_str) if tracking_vis_state.duration_str else 120.0
+    except (TypeError, ValueError):
+        duration_minutes_auto = 120.0  # mid-edit UI text must not crash the loop
+    trajectory_refresh_sec = max(
+        TRAJECTORY_REFRESH_MIN_SEC,
+        TRAJECTORY_REFRESH_FRACTION * (duration_minutes_auto / 2.0) * 60.0)
+    if (current_time - last_trajectory_update >= trajectory_refresh_sec
             and not tracking_vis_state.precompute_in_progress):
-        update_status_callback("Starting trajectory precomputation...")
+        update_status_callback(
+            f"Starting trajectory precomputation ({duration_minutes_auto:.0f} min window, "
+            f"next auto-refresh in ~{trajectory_refresh_sec / 60:.0f} min)...")
         lat = float(config_state.lat_str or 0)
         lon = float(config_state.lon_str or 0)
         alt_m = float(config_state.alt_str or 0)
@@ -344,7 +361,6 @@ while running:
         # Use current time as center and user-specified duration. Snap the center
         # to the quantization grid so the window matches across relaunches (disk
         # cache reuse); the live "now" marker still tracks true time via the slider.
-        duration_minutes_auto = float(tracking_vis_state.duration_str) if tracking_vis_state.duration_str else 120.0
         current_utc = quantized_now()
         tracking_vis_state.t0 = ts.utc(current_utc - timedelta(minutes=duration_minutes_auto/2))
         tracking_vis_state.t1 = ts.utc(current_utc + timedelta(minutes=duration_minutes_auto/2))

--- a/rust/skytracker_core/src/controller.rs
+++ b/rust/skytracker_core/src/controller.rs
@@ -39,6 +39,9 @@ pub struct HotspotParams {
     pub snr_threshold: f64,
     pub gate_radius: f64,
     pub coast_time_s: f64,
+    /// Cap on the centering-correction rate (deg/s). A centering loop that
+    /// lunges at slew rates yanks the target out of its own tracking gate.
+    pub max_rate_dps: f64,
     pub x_sign: f64,
     pub y_sign: f64,
     pub pixel_size_um: f64,
@@ -116,6 +119,7 @@ impl Default for Inputs {
                 snr_threshold: 5.0,
                 gate_radius: 120.0,
                 coast_time_s: 1.0,
+                max_rate_dps: 2.0,
                 x_sign: 1.0,
                 y_sign: -1.0,
                 pixel_size_um: 4.0,
@@ -160,6 +164,21 @@ fn wrap180(deg: f64) -> f64 {
     (deg + 180.0).rem_euclid(360.0) - 180.0
 }
 
+/// Reduce a signed discrete rate step until its physical rate fits under
+/// `cap_rev_s` (rev/sec), keeping at least step 1 so a capped axis still
+/// creeps toward center. Mirrors joystick_controller._issue_axis_rate.
+fn clamp_discrete(rate: i32, cap_rev_s: f64) -> i32 {
+    if rate == 0 {
+        return 0;
+    }
+    let sign = if rate > 0 { 1 } else { -1 };
+    let mut mag: u8 = rate.unsigned_abs().min(9) as u8;
+    while mag > 1 && crate::protocol::rate(mag) > cap_rev_s {
+        mag -= 1;
+    }
+    sign * mag as i32
+}
+
 /// Run hot-spot detection on a frame (gated or full-frame). Returns None when
 /// there is no frame or nothing qualifies. Pure; issues no commands.
 fn detect_in_frame(
@@ -189,6 +208,14 @@ pub struct LoopState {
     hotspot_last_detection_time: f64,
     hotspot_entry_time: f64,
     hotspot_last_frame_seq: Option<u64>,
+    // Fresh-frame arrival time + measured camera cadence (sec) — corrections
+    // are capped so one frame's command can't outrun the next measurement.
+    hotspot_last_fresh_time: f64,
+    hotspot_frame_interval: f64,
+    // Last commanded slew (az_dps, el_dps) + when the gate was anchored, so
+    // the search gate can be shifted by the loop's own commanded motion.
+    hotspot_cmd_dps: (f64, f64),
+    hotspot_gate_time: f64,
 
     // HANDOFF: consecutive-detection counter toward the auto hand-off.
     handoff_detection_count: u32,
@@ -213,6 +240,10 @@ impl LoopState {
             hotspot_last_detection_time: 0.0,
             hotspot_entry_time: 0.0,
             hotspot_last_frame_seq: None,
+            hotspot_last_fresh_time: 0.0,
+            hotspot_frame_interval: 0.2,
+            hotspot_cmd_dps: (0.0, 0.0),
+            hotspot_gate_time: 0.0,
             handoff_detection_count: 0,
             program_had_setpoint: false,
         }
@@ -268,6 +299,10 @@ impl LoopState {
                     self.hotspot_last_detection_time = 0.0;
                     self.hotspot_entry_time = now;
                     self.hotspot_last_frame_seq = None;
+                    self.hotspot_last_fresh_time = 0.0;
+                    self.hotspot_frame_interval = 0.2;
+                    self.hotspot_cmd_dps = (0.0, 0.0);
+                    self.hotspot_gate_time = 0.0;
                 }
                 Mode::Handoff => {
                     self.handoff_detection_count = 0;
@@ -545,10 +580,60 @@ impl LoopState {
         }
         let frame = if frame_is_stale { None } else { frame };
 
-        // Detect on this cycle's frame (gated to the last lock once acquired).
-        let gate = self
-            .hotspot_gate_center
-            .map(|(cx, cy)| (cx, cy, hp.gate_radius));
+        // Measured fresh-frame interval (hit OR miss): gate prediction and the
+        // correction-rate cap are sized to it, so the loop never outruns its
+        // own measurements. Mirrors hotspot_track.
+        if frame.is_some() {
+            if self.hotspot_last_fresh_time > 0.0 {
+                self.hotspot_frame_interval =
+                    (now - self.hotspot_last_fresh_time).clamp(0.05, 2.0);
+            }
+            self.hotspot_last_fresh_time = now;
+        }
+
+        // The optical geometry needs the SKY elevation (azimuth compresses by
+        // cos(el) on the sky); in AltAz the mount ALT axis is 90 - el, and
+        // passing it raw overstates the azimuth error by cos(el)/cos(ALT) --
+        // a divergent overshoot at moderate elevations.
+        let el_sky = if inputs.mount_mode == MountMode::AltAz {
+            90.0 - current_alt
+        } else {
+            current_alt
+        };
+
+        // Detect on this cycle's frame, gated to the last lock once acquired.
+        // The gate is PREDICTED forward by the boresight motion we ourselves
+        // commanded since the frame it was anchored on (with a narrow FOV a
+        // legitimate correction sweeps a large pixel distance between frames),
+        // and GROWS on consecutive misses so residual prediction error or
+        // target motion can't strand it while the target is still in frame.
+        let gate = self.hotspot_gate_center.map(|(cx, cy)| {
+            let (az_dps, alt_dps) = self.hotspot_cmd_dps;
+            let gate_dt = (now - self.hotspot_gate_time).max(0.0);
+            let (mut gx, mut gy) = (cx, cy);
+            if gate_dt > 0.0 && (az_dps != 0.0 || alt_dps != 0.0) {
+                let el_sky_dps = if inputs.mount_mode == MountMode::AltAz {
+                    -alt_dps
+                } else {
+                    alt_dps
+                };
+                let (pdx, pdy) = hotspot::angles_to_pixel_offset(
+                    -az_dps * gate_dt,
+                    -el_sky_dps * gate_dt,
+                    hp.pixel_size_um,
+                    hp.focal_length_mm,
+                    hp.rotation_deg,
+                    el_sky,
+                    hp.x_sign,
+                    hp.y_sign,
+                    true,
+                );
+                gx += pdx;
+                gy += pdy;
+            }
+            let growth = 1.5f64.powi(self.hotspot_miss_count.min(8) as i32).min(4.0);
+            (gx, gy, hp.gate_radius * growth)
+        });
         let detection = detect_in_frame(frame, &hp, gate);
 
         if let Some(det) = detection {
@@ -561,7 +646,7 @@ impl LoopState {
                 hp.pixel_size_um,
                 hp.focal_length_mm,
                 hp.rotation_deg,
-                current_alt,
+                el_sky,
                 hp.x_sign,
                 hp.y_sign,
                 true,
@@ -591,7 +676,24 @@ impl LoopState {
                 self.alt_pid
                     .compute_pid_output(el_error, dt, Some(current_alt));
 
+            // Cap each axis so the correction covers at most ~90% of the
+            // remaining error before the NEXT measurement (measured frame
+            // interval): a correction that outruns its measurements
+            // overshoots, exits its own gate, and coasts into a stair-step.
+            let interval = self.hotspot_frame_interval.max(0.05);
+            let cap_az = (hp.max_rate_dps / 360.0).min(0.9 * az_error.abs() / interval / 360.0);
+            let cap_al = (hp.max_rate_dps / 360.0).min(0.9 * el_error.abs() / interval / 360.0);
+            let az_out = az_out.clamp(-cap_az, cap_az);
+            let al_out = al_out.clamp(-cap_al, cap_al);
+            let az_rate = clamp_discrete(az_rate, cap_az);
+            let al_rate = clamp_discrete(al_rate, cap_al);
+            // Remember what we commanded (mount frame, deg/s) for the gate
+            // prediction. The threaded loop actuates az_out/al_out (continuous)
+            // or the discrete steps; either way this is the commanded motion.
+            self.hotspot_cmd_dps = (az_out * 360.0, al_out * 360.0);
+
             self.hotspot_gate_center = Some((det.cx, det.cy));
+            self.hotspot_gate_time = now;
             self.hotspot_acquired = true;
             self.hotspot_miss_count = 0;
             self.hotspot_last_detection_time = now;
@@ -613,6 +715,26 @@ impl LoopState {
         // not a miss -- only count misses against frames actually examined.
         if !frame_is_stale {
             self.hotspot_miss_count += 1;
+            // Bleed off the held correction: rates persist on the mount, and
+            // a correction that hasn't been re-confirmed by a detection must
+            // not keep integrating (a single overshoot would otherwise coast
+            // into an FOV-sized stair-step). Halve per missed frame.
+            let (mut az_d, mut el_d) = self.hotspot_cmd_dps;
+            if az_d.abs() > 1e-3 || el_d.abs() > 1e-3 {
+                az_d *= 0.5;
+                el_d *= 0.5;
+                if az_d.abs() < 1e-3 {
+                    az_d = 0.0;
+                }
+                if el_d.abs() < 1e-3 {
+                    el_d = 0.0;
+                }
+                self.hotspot_cmd_dps = (az_d, el_d);
+                out.azm_pid_output = az_d / 360.0;
+                out.alt_pid_output = el_d / 360.0;
+                out.azm_rate_cmd = Some(0);
+                out.alt_rate_cmd = Some(0);
+            }
         }
 
         if self.hotspot_acquired {

--- a/rust/skytracker_core/src/hotspot.rs
+++ b/rust/skytracker_core/src/hotspot.rs
@@ -243,3 +243,39 @@ pub fn pixel_offset_to_angles(
 
     (az_err, el_err)
 }
+
+/// Inverse of `pixel_offset_to_angles` (mirrors `simulator.angles_to_pixel`):
+/// angular offset from boresight -> pixel offset from image center. Used by
+/// the tracking-gate prediction to move the search window by the boresight
+/// motion the loop itself commanded between frames.
+#[allow(clippy::too_many_arguments)]
+pub fn angles_to_pixel_offset(
+    d_az_deg: f64,
+    d_el_deg: f64,
+    pixel_size_um: f64,
+    focal_length_mm: f64,
+    rotation_deg: f64,
+    el_deg: f64,
+    x_sign: f64,
+    y_sign: f64,
+    apply_cos_el: bool,
+) -> (f64, f64) {
+    if focal_length_mm == 0.0 {
+        return (0.0, 0.0);
+    }
+    let ifov_deg = ((pixel_size_um * 1e-3) / focal_length_mm).to_degrees();
+
+    let cross_el = if apply_cos_el {
+        d_az_deg * el_deg.to_radians().cos()
+    } else {
+        d_az_deg
+    };
+    let el_err = d_el_deg;
+
+    let th = rotation_deg.to_radians();
+    let (cos_t, sin_t) = (th.cos(), th.sin());
+    let ax = cross_el * cos_t + el_err * sin_t;
+    let ay = -cross_el * sin_t + el_err * cos_t;
+
+    (ax / (ifov_deg * x_sign), ay / (ifov_deg * y_sign))
+}

--- a/rust/skytracker_core/src/python_bindings.rs
+++ b/rust/skytracker_core/src/python_bindings.rs
@@ -489,6 +489,7 @@ impl SimCoreLoop {
         self.shared.inputs.lock().unwrap().handoff_min_frames = n;
     }
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (snr_threshold, gate_radius, coast_time_s, x_sign, y_sign, pixel_size_um, focal_length_mm, rotation_deg, max_rate_dps = 2.0))]
     fn set_hotspot_params(
         &self,
         snr_threshold: f64,
@@ -499,6 +500,7 @@ impl SimCoreLoop {
         pixel_size_um: f64,
         focal_length_mm: f64,
         rotation_deg: f64,
+        max_rate_dps: f64,
     ) {
         self.shared.inputs.lock().unwrap().hotspot = crate::controller::HotspotParams {
             snr_threshold,
@@ -509,6 +511,7 @@ impl SimCoreLoop {
             pixel_size_um,
             focal_length_mm,
             rotation_deg,
+            max_rate_dps,
         };
     }
 
@@ -673,11 +676,13 @@ fn h_set_hotspot_params(
     px: f64,
     fl: f64,
     rot: f64,
+    max_rate_dps: f64,
 ) {
     sh.inputs.lock().unwrap().hotspot = HotspotParams {
         snr_threshold: snr,
         gate_radius: gate,
         coast_time_s: coast,
+        max_rate_dps,
         x_sign: xs,
         y_sign: ys,
         pixel_size_um: px,
@@ -906,6 +911,7 @@ impl CoreLoop {
         h_set_handoff_min_frames(self.inner.shared(), n);
     }
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (snr_threshold, gate_radius, coast_time_s, x_sign, y_sign, pixel_size_um, focal_length_mm, rotation_deg, max_rate_dps = 2.0))]
     fn set_hotspot_params(
         &self,
         snr_threshold: f64,
@@ -916,6 +922,7 @@ impl CoreLoop {
         pixel_size_um: f64,
         focal_length_mm: f64,
         rotation_deg: f64,
+        max_rate_dps: f64,
     ) {
         h_set_hotspot_params(
             self.inner.shared(),
@@ -927,6 +934,7 @@ impl CoreLoop {
             pixel_size_um,
             focal_length_mm,
             rotation_deg,
+            max_rate_dps,
         );
     }
     fn push_frame(&mut self, image: PyReadonlyArray2<'_, f32>) {

--- a/rust/skytracker_core/tests/controller.rs
+++ b/rust/skytracker_core/tests/controller.rs
@@ -231,11 +231,16 @@ fn hotspot_coasts_on_brief_dropout() {
     let f = blob_frame(256, 200, 138.0, 110.0);
     let o1 = s.step(&i, Some(&f), 50.0, 45.0, 100.0);
     assert!(o1.hotspot_acquired);
-    // Dropout within coast window -> coast, no new command, stays in HOTSPOT.
+    assert!(o1.azm_pid_output != 0.0, "off-center blob must command a correction");
+    // Dropout within coast window -> coast, stays in HOTSPOT, but the held
+    // correction decays (halves) rather than integrating unconfirmed motion.
     let o2 = s.step(&i, None, 50.0, 45.0, 100.5);
     assert_eq!(o2.hotspot_status, "coasting");
-    assert_eq!(o2.azm_rate_cmd, None);
     assert_eq!(o2.requested_mode, None);
+    assert!(
+        (o2.azm_pid_output - 0.5 * o1.azm_pid_output).abs() < 1e-12,
+        "held rate must halve per missed frame"
+    );
     // Past the coast window -> lost, hand back to PROGRAM.
     let o3 = s.step(&i, None, 50.0, 45.0, 102.0);
     assert_eq!(o3.hotspot_status, "lost");

--- a/rust_loop_adapter.py
+++ b/rust_loop_adapter.py
@@ -516,6 +516,7 @@ class RustCoreLoopAdapter:
             float(cfg.get_camera_pixel_size(cam_name)),
             float(cfg.get_camera_focal_length(cam_name)),
             float(cfg.get_camera_alignment_rotation(cam_name)),
+            float(getattr(cfg, "hotspot_max_rate_dps", 2.0) or 2.0),
         )
         camera = camera_manager.get_camera(cam_index)
         if camera is not None and getattr(camera, "thread", None) is not None:

--- a/test_mode_machine.py
+++ b/test_mode_machine.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+"""
+Live-fidelity mode-machine integration tests: PROGRAM -> HANDOFF -> HOTSPOT
+against the hardware simulator, driven through the REAL tracking_control
+dispatch at control-loop cadence with camera frames arriving at a realistic
+frame rate (so the stale-frame gate is exercised, unlike the older
+convergence test whose fake camera rendered fresh on every read).
+
+Field symptoms this suite exists to reproduce/pin:
+  * HANDOFF centering briefly then walking off in FOV-sized stair-steps,
+  * HOTSPOT failing to acquire and reverting to PROGRAM immediately.
+
+Wall-clock based (the Python PID takes dt from time.time()), so each
+scenario runs for a few real seconds.
+
+Headless. Run: python test_mode_machine.py
+"""
+
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import math
+import time
+import unittest
+
+import pygame
+pygame.init()
+
+from config import ConfigState
+from lib.auxstar import Targets
+import simulator
+from simulator import HardwareSimulator
+
+import joystick_controller as jc
+from joystick_controller import JoystickModeState, TrackingMode
+
+
+class _FakeJoystick:
+    def get_numaxes(self):
+        return 6
+
+    def get_axis(self, i):
+        return 0.0
+
+    def get_instance_id(self):
+        return 0
+
+
+class _PacedThread:
+    """Camera thread stand-in that renders at a fixed frame rate and exposes
+    latest_raw_seq -- so the control loop sees stale frames between captures,
+    exactly like the real CameraThread."""
+
+    def __init__(self, sim, cam_index=0, fps=20.0):
+        self.sim = sim
+        self.cam_index = cam_index
+        self.period = 1.0 / fps
+        self._last = 0.0
+        self.latest_raw = None
+        self.latest_raw_seq = 0
+
+    def get_latest_raw(self):
+        now = time.time()
+        if self.latest_raw is None or (now - self._last) >= self.period:
+            self._last = now
+            self.latest_raw = self.sim.render_frame(self.cam_index)
+            self.latest_raw_seq += 1
+        return self.latest_raw
+
+
+class _Cam:
+    def __init__(self, thread):
+        self.thread = thread
+
+
+class _Vis:
+    selected_launch = None
+    launch_launched = False
+    selected_aircraft = None
+    aircraft_trajectories = {}
+    current_tt = 0.0
+
+    def __init__(self):
+        self.selected_satellite = "SIMSAT"
+        self.satellite_trajectories = {"SIMSAT": ([(0,)] * 8, [0.0])}
+        self.telescope_azimuth = 0.0
+        self.telescope_altitude = 0.0
+
+
+class _Rig:
+    """One live-fidelity tracking rig: sim mount + paced sim camera + real
+    JoystickModeState driven through tracking_control at 15 Hz."""
+
+    def __init__(self, az_rate_dps=0.25, el_rate_dps=0.0, start_offset=None,
+                 fps=20.0, tuned=True):
+        cfg = ConfigState()
+        if tuned:
+            # Live fidelity: the field-tuned configuration (continuous
+            # guide-rate tracking, tuned PID gains, lead time) from the
+            # committed example config -- with the sim-scenario site geometry
+            # (alignment/offsets zero) overlaid.
+            import json
+            cfg.load_from_dict(json.load(open("config.example.json")))
+        else:
+            # Legacy/fallback configuration: discrete MC_MOVE rate steps and
+            # a plain P controller -- coarser (sawtooth) by design.
+            cfg.continuous_rate_tracking = False
+            cfg.pid_azm_p_gain = cfg.pid_alt_p_gain = 0.3
+            cfg.pid_azm_i_gain = cfg.pid_alt_i_gain = 0.0
+            cfg.pid_azm_d_gain = cfg.pid_alt_d_gain = 0.0
+        cfg.sim_config["enabled"] = True
+        cfg.azm_offset_str = "0"
+        cfg.alt_offset_str = "0"
+        cfg.alignment_azimuth_str = "0.0"
+        cfg.alignment_elevation_str = "0.0"
+        cfg.mount_mode = "AltAz"
+        self.cfg = cfg
+
+        self.t0 = time.time()
+        self.az0, self.el0 = 100.0, 30.0
+        self.az_rate, self.el_rate = az_rate_dps, el_rate_dps
+
+        self.sim = HardwareSimulator(cfg, None, None)
+        self.sim.current_target_azel = lambda: (*self.target_azel(), 'satellite', True)
+        # Start off-target but INSIDE the tracking camera's FOV (the optical
+        # modes can only acquire what is in frame; the configured camera
+        # geometry may be far narrower than "wide" suggests). Default offset:
+        # half the half-FOV on each axis.
+        pix = float(cfg.get_camera_pixel_size("camera1"))
+        foc = float(cfg.get_camera_focal_length("camera1"))
+        ifd = 206.0 * pix / foc / 3600.0    # deg per pixel
+        w = int(cfg.sim_config.get("cam_width", 960))
+        h = int(cfg.sim_config.get("cam_height", 720))
+        self.fov_x = w * ifd / 2.0          # half-FOV, deg
+        self.fov_y = h * ifd / 2.0
+        if start_offset is None:
+            start_offset = (self.fov_x * 0.5, self.fov_y * 0.5)
+        self.sim.mount.az_true_deg = self.az0 + start_offset[0]
+        self.sim.mount.el_true_deg = (90.0 - self.el0) + start_offset[1]
+
+        self.state = JoystickModeState(None, cfg, self._status)
+        self.state.hardware_sim = self.sim
+        self.state.telescope_connected = True
+        self.state.telescope_controller = self.sim.mount
+        self.state.feed_forward_azm_enabled = tuned
+        self.state.feed_forward_alt_enabled = tuned
+        self.state.tracking_vis_state = _Vis()
+        joy = _FakeJoystick()
+        self.state.joysticks = {0: joy}
+        self.state.connected_joystick = 0
+        self.state.joystick_tare = {}
+
+        self.thread = _PacedThread(self.sim, 0, fps=fps)
+        self._orig_get_camera = jc.camera_manager.get_camera
+        jc.camera_manager.get_camera = lambda idx: _Cam(self.thread)
+
+        self._orig_interp = jc.interpolate_position_data_and_rates
+        jc.interpolate_position_data_and_rates = self._interp
+
+        self.messages = []
+        self.pointing_log = []   # (t, sky_err_deg)
+
+    def _status(self, msg):
+        self.messages.append(msg)
+
+    def target_azel(self, t=None):
+        dt = (t if t is not None else time.time()) - self.t0
+        return (self.az0 + self.az_rate * dt) % 360.0, self.el0 + self.el_rate * dt
+
+    def _interp(self, traj, tt, *a, **k):
+        az, el = self.target_azel()
+        return (1.0, 1.0, el, 500.0, az, self.az_rate, self.el_rate)
+
+    def sky_error_deg(self):
+        """Angular error between the sim mount's true pointing and the target."""
+        taz, tel = self.target_azel()
+        maz, mel = simulator.normalize_azel(
+            self.sim.mount.az_true_deg, 90.0 - self.sim.mount.el_true_deg)
+        return math.hypot(simulator.wrap180(maz - taz) *
+                          math.cos(math.radians(tel)), mel - tel)
+
+    def run(self, seconds, hz=15.0):
+        """Drive the REAL control dispatch (mode entry logic included) like
+        MountControlThread does, logging the sky error each cycle."""
+        period = 1.0 / hz
+        end = time.time() + seconds
+        while time.time() < end:
+            c0 = time.perf_counter()
+            self.state.current_azm = self.sim.mount.hc_get_position(Targets.AZM) * 360.0
+            self.state.current_alt = self.sim.mount.hc_get_position(Targets.ALT) * 360.0
+            self.state.current_azm_raw = self.state.current_azm
+            self.state.current_alt_raw = self.state.current_alt
+            self.state.tracking_control()
+            self.pointing_log.append((time.time() - self.t0, self.sky_error_deg()))
+            sleep = period - (time.perf_counter() - c0)
+            if sleep > 0:
+                time.sleep(sleep)
+
+    def close(self):
+        jc.camera_manager.get_camera = self._orig_get_camera
+        jc.interpolate_position_data_and_rates = self._orig_interp
+
+    def max_error_after(self, t_settle):
+        errs = [e for (t, e) in self.pointing_log
+                if t >= t_settle + (self.pointing_log[0][0] if self.pointing_log else 0)]
+        return max(errs) if errs else float("inf")
+
+
+class ProgramTrackingTests(unittest.TestCase):
+
+    def test_program_tracks_tightly_with_tuned_config(self):
+        # Continuous guide-rate + feed-forward + tuned gains (the field
+        # config): the loop should hold a moving target within ~0.2 deg.
+        rig = _Rig()
+        try:
+            rig.state.tracking_mode = TrackingMode.PROGRAM
+            rig.run(6.0)
+        finally:
+            rig.close()
+        self.assertEqual(rig.state.tracking_mode, TrackingMode.PROGRAM)
+        errs = [e for (t, e) in rig.pointing_log]
+        settled = errs[len(errs) // 2:]
+        self.assertLess(max(settled), 0.2,
+                        f"PROGRAM (tuned) walked off: max settled error {max(settled):.2f} deg "
+                        f"(errors tail: {[f'{e:.2f}' for e in settled[-10:]]})")
+
+    def test_program_bounded_with_discrete_fallback_config(self):
+        # Discrete MC_MOVE steps produce the known sawtooth; it must stay
+        # BOUNDED (a limit cycle), never walk off.
+        rig = _Rig(tuned=False)
+        try:
+            rig.state.tracking_mode = TrackingMode.PROGRAM
+            rig.run(6.0)
+        finally:
+            rig.close()
+        self.assertEqual(rig.state.tracking_mode, TrackingMode.PROGRAM)
+        errs = [e for (t, e) in rig.pointing_log]
+        settled = errs[len(errs) // 2:]
+        self.assertLess(max(settled), 1.2,
+                        f"PROGRAM (discrete) diverged: max settled error {max(settled):.2f} deg")
+
+
+class HandoffTests(unittest.TestCase):
+
+    def test_handoff_engages_hotspot_and_keeps_tracking(self):
+        rig = _Rig()
+        try:
+            rig.state.tracking_mode = TrackingMode.HANDOFF
+            rig.run(8.0)
+        finally:
+            rig.close()
+        self.assertEqual(
+            rig.state.tracking_mode, TrackingMode.HOTSPOT,
+            f"HANDOFF should have engaged HOTSPOT and HELD it; "
+            f"mode={rig.state.tracking_mode} status={rig.state.hotspot_status!r} "
+            f"messages={rig.messages[-6:]}")
+        errs = [e for (t, e) in rig.pointing_log]
+        settled = errs[len(errs) // 2:]
+        self.assertLess(max(settled), 0.8,
+                        f"walked off after handoff: max settled error {max(settled):.2f} deg")
+
+
+class HotspotTests(unittest.TestCase):
+
+    def test_hotspot_acquires_and_holds_on_moving_target(self):
+        rig = _Rig()
+        try:
+            rig.state.tracking_mode = TrackingMode.HOTSPOT
+            rig.run(6.0)
+        finally:
+            rig.close()
+        self.assertEqual(
+            rig.state.tracking_mode, TrackingMode.HOTSPOT,
+            f"HOTSPOT reverted (status={rig.state.hotspot_status!r}, "
+            f"messages={rig.messages[-6:]})")
+        self.assertTrue(rig.state.hotspot_acquired)
+        errs = [e for (t, e) in rig.pointing_log]
+        settled = errs[len(errs) // 2:]
+        self.assertLess(max(settled), 0.8,
+                        f"HOTSPOT walked off: max settled error {max(settled):.2f} deg")
+
+    def test_hotspot_survives_slow_frames(self):
+        # 4 fps camera vs 15 Hz control loop: mostly-stale frames must ride
+        # the stale gate + coast, not trip the loss fallback.
+        rig = _Rig(fps=4.0)
+        try:
+            rig.state.tracking_mode = TrackingMode.HOTSPOT
+            rig.run(5.0)
+        finally:
+            rig.close()
+        self.assertEqual(rig.state.tracking_mode, TrackingMode.HOTSPOT,
+                         f"reverted on slow frames (status={rig.state.hotspot_status!r})")
+
+    def test_hotspot_with_target_out_of_fov_falls_back_to_program(self):
+        # Engaged with nothing (or only stars) in frame, HOTSPOT must decline
+        # gracefully -- fall back to PROGRAM, which re-centers -- rather than
+        # chase a star or sit dead. This is the designed division of labor:
+        # PROGRAM owns acquisition, HOTSPOT owns centering.
+        rig = _Rig(start_offset=(3.0, 1.5))  # far outside the ~0.5 deg FOV
+        try:
+            rig.state.tracking_mode = TrackingMode.HOTSPOT
+            rig.run(6.0)
+        finally:
+            rig.close()
+        self.assertEqual(rig.state.tracking_mode, TrackingMode.PROGRAM,
+                         "should have handed back to PROGRAM for re-acquisition")
+        errs = [e for (t, e) in rig.pointing_log]
+        self.assertLess(errs[-1], 0.3,
+                        f"PROGRAM should be re-centering after fallback, err={errs[-1]:.2f}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes both issues from the latest field report.

## 1. Trajectory recomputed every 15 minutes despite a 2-hour window

The background precompute re-fired on a fixed 900 s timer regardless of the window it had just built. It now refreshes when live time has consumed **75% of the forward half** of the window (the window is centered on "now" at compute time), with a 5-minute floor. A 2 h window refreshes after ~45 min; the status message now says when the next auto-refresh is due. (`main.py`)

## 2. HANDOFF stair-step walk-off / HOTSPOT instant revert to PROGRAM

A new live-fidelity harness — the real `tracking_control()` state machine driving the simulated mount through a paced camera thread, using the tuned `config.example.json` gains and the real camera1 FOV (±0.49°×±0.37°) — reproduced the walk-off immediately. Four compounding bugs, fixed on both the Python and Rust paths:

1. **Wrong elevation frame in the optical geometry.** `pixel_offset_to_angles` needs SKY elevation for the cos(el) azimuth compression, but got the mount ALT axis (`90 − el` in AltAz) — ~1.73× azimuth overshoot at el = 30°, i.e. divergent. This alone produces the stair-step.
2. **Corrections capped only at slew scale.** New `hotspot_max_rate_dps` config (default 2.0°/s — HOTSPOT is a centering loop, not a slew), plus a cadence cap: never cover more than ~90% of the remaining error per **measured** frame interval, so the loop can't outrun its own measurements.
3. **Static tracking gate.** The loop's own commanded slew streamed the target out of its own search window → instant "lost". The gate is now predicted forward by the commanded rates (anchored at the last detection) and grows 1.5×/miss (cap 4×).
4. **Held rates never decayed on miss.** One overshoot coasted into the next stair-step. Held rates now halve per missed fresh frame — a one-frame dropout still coasts, sustained loss bleeds to zero.

Rust mirror: `step_hotspot` reworked identically; `hotspot::angles_to_pixel_offset` added as the exact inverse transform for gate prediction; `set_hotspot_params` gains a defaulted `max_rate_dps` parameter (old callers keep working).

## Testing

- **New `test_mode_machine.py`** (6 closed-loop scenarios): tuned PROGRAM tracking <0.2°, discrete-fallback PROGRAM bounded, HANDOFF engages HOTSPOT and keeps tracking, HOTSPOT acquires/holds a moving target, survives 4 fps frames, and falls back to PROGRAM when the target is out of FOV (then re-centers).
- Rust `cargo test --release`: all suites pass (coast test updated for the intentional decay behavior).
- Full suite after wheel rebuild: **319 passed, 2 skipped** (includes the Rust A/B parity harness).
- `LEARNINGS.md` entry documents the four failure modes and the closed-loop-harness principle.

⚠️ Not hardware-validated — verified against the mount/camera simulation per the standing constraint. `hotspot_max_rate_dps` is bench-tunable in config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNc5zKNJEYoBXdn97USgXj)_